### PR TITLE
LG-2766/fixAboutUsImages

### DIFF
--- a/src/components/TeamMembers.jsx
+++ b/src/components/TeamMembers.jsx
@@ -1,0 +1,82 @@
+// @flow
+
+import React from 'react';
+import { Link } from 'gatsby';
+import Img from 'gatsby-image';
+
+import { withI18n } from '@lingui/react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faTwitter, faLinkedin } from '@fortawesome/free-brands-svg-icons';
+import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
+
+import { shuffleArray } from '../helpers';
+import { type AuthorProps } from '../layouts/team';
+
+const TeamMember = withI18n()(
+  ({
+    name,
+    role,
+    description,
+    img,
+    twitter,
+    linkedIn,
+    mail,
+    article,
+  }: {|
+    ...AuthorProps,
+    img: Object,
+  |}) => {
+    const ProfileImage = <Img {...img} className="mx-auto" alt={name} />;
+    return (
+      <div className="ledgista col-12 col-md-6 col-lg-4">
+        <div className="pb-6 h-100 d-flex flex-column align-items-center justify-content-between">
+          <div className="d-flex flex-column align-items-center">
+            <div className="ledgista-image-wrapper">
+              {article ? (
+                <Link href to={`/updates/${article}/`}>
+                  {ProfileImage}
+                </Link>
+              ) : (
+                ProfileImage
+              )}
+            </div>
+            <div className="text-center d-flex flex-column align-items-center">
+              <div>
+                <h4 className="mt-2 mb-0">{name}</h4>
+                <small className="text-muted">{role}</small>
+                <p className="mt-2 font-weight-light">{description}</p>
+              </div>
+            </div>
+          </div>
+          <div className="d-flex align-items-center">
+            <a className="social-icon mr-3" href={`mailto:${mail}`}>
+              <FontAwesomeIcon icon={faEnvelope} />
+            </a>
+            {twitter ? (
+              <a className="social-icon mr-3" href={twitter}>
+                <FontAwesomeIcon icon={faTwitter} />
+              </a>
+            ) : (
+              <span />
+            )}
+            <a className="social-icon" href={linkedIn}>
+              <FontAwesomeIcon icon={faLinkedin} />
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+export const TeamMembers = ({ teamData }: {| teamData: [AuthorProps, any][] |}) => {
+  const shuffledTeam = shuffleArray(teamData);
+
+  return (
+    <div className="row justify-content-center my-5">
+      {shuffledTeam.map(([memberProps, img]) => (
+        <TeamMember {...memberProps} img={img} key={`team-${memberProps.name}`} />
+      ))}
+    </div>
+  );
+};

--- a/src/components/TeamMembers.jsx
+++ b/src/components/TeamMembers.jsx
@@ -74,10 +74,9 @@ export const TeamMembers = ({ teamData }: {| teamData: [AuthorProps, any][] |}) 
 
   return (
     <div className="row justify-content-center my-5">
-      {team.map(([memberProps, img]) => {
-        console.log({ memberProps, img });
-        return <TeamMember {...memberProps} img={img} key={`team-${memberProps.name}`} />;
-      })}
+      {team.map(([memberProps, img]) => (
+        <TeamMember {...memberProps} img={img} key={`team-${memberProps.name}`} />
+      ))}
     </div>
   );
 };

--- a/src/components/TeamMembers.jsx
+++ b/src/components/TeamMembers.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'gatsby';
 import Img from 'gatsby-image';
 
@@ -66,13 +66,18 @@ const TeamMember = withI18n()(
 );
 
 export const TeamMembers = ({ teamData }: {| teamData: [AuthorProps, any][] |}) => {
-  const shuffledTeam = shuffleArray(teamData);
+  const [team, setTeam] = useState(teamData);
+
+  useEffect(() => {
+    setTeam((prev) => shuffleArray(prev));
+  }, []);
 
   return (
     <div className="row justify-content-center my-5">
-      {shuffledTeam.map(([memberProps, img]) => (
-        <TeamMember {...memberProps} img={img} key={`team-${memberProps.name}`} />
-      ))}
+      {team.map(([memberProps, img]) => {
+        console.log({ memberProps, img });
+        return <TeamMember {...memberProps} img={img} key={`team-${memberProps.name}`} />;
+      })}
     </div>
   );
 };

--- a/src/components/TeamMembers.jsx
+++ b/src/components/TeamMembers.jsx
@@ -52,13 +52,9 @@ const TeamMember = withI18n()(
             <a className="social-icon mr-3" href={`mailto:${mail}`}>
               <FontAwesomeIcon icon={faEnvelope} />
             </a>
-            {twitter ? (
-              <a className="social-icon mr-3" href={twitter}>
-                <FontAwesomeIcon icon={faTwitter} />
-              </a>
-            ) : (
-              <span />
-            )}
+            <a className={`social-icon mr-3 ${twitter ? '' : 'd-none'}`} href={twitter || ''}>
+              <FontAwesomeIcon icon={faTwitter} />
+            </a>
             <a className="social-icon" href={linkedIn}>
               <FontAwesomeIcon icon={faLinkedin} />
             </a>

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -24,7 +24,7 @@ export const animateLaptop = () => {
 
 export const isFieldMissing = (object: Object) => Object.values(object).some((field) => !field);
 
-export const shuffleArray = (array: any[]) =>
+export const shuffleArray = <T>(array: T[]): T[] =>
   array.reduce((res, val, index) => {
     const randomIndex = Math.floor(Math.random() * (index + 1));
     const copy = [...res];

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -24,15 +24,11 @@ export const animateLaptop = () => {
 
 export const isFieldMissing = (object: Object) => Object.values(object).some((field) => !field);
 
-export const shuffleArray = (array: any[]) => {
-  const arrayCopy = array;
-  let index = arrayCopy.length - 1;
-  // eslint-disable-next-line no-plusplus
-  for (index; index > 0; index--) {
-    const random = Math.floor(Math.random() * (index + 1));
-    const temp = arrayCopy[index];
-    arrayCopy[index] = arrayCopy[random];
-    arrayCopy[random] = temp;
-  }
-  return arrayCopy;
-};
+export const shuffleArray = (array: any[]) =>
+  array.reduce((res, val, index) => {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    const copy = [...res];
+    copy[index] = copy[randomIndex];
+    copy[randomIndex] = val;
+    return copy;
+  }, array);

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -24,11 +24,15 @@ export const animateLaptop = () => {
 
 export const isFieldMissing = (object: Object) => Object.values(object).some((field) => !field);
 
-export const shuffleArray = (array: any[]) =>
-  array.reduce((res, val, index) => {
-    const randomIndex = Math.floor(Math.random() * (index + 1));
-    const copy = [...res];
-    copy[index] = copy[randomIndex];
-    copy[randomIndex] = val;
-    return copy;
-  }, array);
+export const shuffleArray = (array: any[]) => {
+  const arrayCopy = array;
+  let index = arrayCopy.length - 1;
+  // eslint-disable-next-line no-plusplus
+  for (index; index > 0; index--) {
+    const random = Math.floor(Math.random() * (index + 1));
+    const temp = arrayCopy[index];
+    arrayCopy[index] = arrayCopy[random];
+    arrayCopy[random] = temp;
+  }
+  return arrayCopy;
+};

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -48,7 +48,6 @@ const IndexPage = (props: Props) => {
     [team.mariana, data.mariana],
     [team.luna, data.luna],
   ];
-  console.log({ teamData });
 
   return (
     <div>

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -48,6 +48,7 @@ const IndexPage = (props: Props) => {
     [team.mariana, data.mariana],
     [team.luna, data.luna],
   ];
+  console.log({ teamData });
 
   return (
     <div>

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -2,74 +2,14 @@
 
 import React from 'react';
 import Img from 'gatsby-image';
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import { withI18n, Trans } from '@lingui/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTwitter, faLinkedin } from '@fortawesome/free-brands-svg-icons';
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons';
 
-import { shuffleArray } from '../helpers';
 import { Title, Hr } from '../layouts/utils';
-import { getWholeTeam, type AuthorProps } from '../layouts/team';
+import { getWholeTeam } from '../layouts/team';
 
 import { PageHeader } from '../components/PageHeader';
-
-const TeamMember = withI18n()(
-  ({
-    name,
-    role,
-    description,
-    img,
-    twitter,
-    linkedIn,
-    mail,
-    article,
-  }: {|
-    ...AuthorProps,
-    img: Object,
-  |}) => {
-    const ProfileImage = <Img {...img} className="mx-auto" alt={name} />;
-    return (
-      <div className="ledgista col-12 col-md-6 col-lg-4">
-        <div className="pb-6 h-100 d-flex flex-column align-items-center justify-content-between">
-          <div className="d-flex flex-column align-items-center">
-            <div className="ledgista-image-wrapper">
-              {article ? (
-                <Link href to={`/updates/${article}/`}>
-                  {ProfileImage}
-                </Link>
-              ) : (
-                ProfileImage
-              )}
-            </div>
-            <div className="text-center d-flex flex-column align-items-center">
-              <div>
-                <h4 className="mt-2 mb-0">{name}</h4>
-                <small className="text-muted">{role}</small>
-                <p className="mt-2 font-weight-light">{description}</p>
-              </div>
-            </div>
-          </div>
-          <div>
-            <a className="social-icon mr-3" href={`mailto:${mail}`}>
-              <FontAwesomeIcon icon={faEnvelope} />
-            </a>
-            {twitter ? (
-              <a className="social-icon mr-3" href={twitter}>
-                <FontAwesomeIcon icon={faTwitter} />
-              </a>
-            ) : (
-              <span />
-            )}
-            <a className="social-icon" href={linkedIn}>
-              <FontAwesomeIcon icon={faLinkedin} />
-            </a>
-          </div>
-        </div>
-      </div>
-    );
-  }
-);
+import { TeamMembers } from '../components/TeamMembers';
 
 const Investor = ({
   name,
@@ -92,7 +32,7 @@ const IndexPage = (props: Props) => {
   const team = getWholeTeam(props.prefix);
   const title = i18n.t`About us`;
   const description = i18n.t`We believe that entrepreneurship is the main driver of positive change in the world. That is why we build beautiful and intuitive software for startups, helping them be more successful`;
-  const teamArray = shuffleArray([
+  const teamData = [
     [team.timo, data.timo],
     [team.yoko, data.yoko],
     [team.ben, data.ben],
@@ -107,7 +47,7 @@ const IndexPage = (props: Props) => {
     [team.tamas, data.tamas],
     [team.mariana, data.mariana],
     [team.luna, data.luna],
-  ]);
+  ];
 
   return (
     <div>
@@ -119,11 +59,7 @@ const IndexPage = (props: Props) => {
           <Trans>Team</Trans>
         </h2>
 
-        <div className="row justify-content-center my-5">
-          {teamArray.map(([memberProps, img]) => (
-            <TeamMember {...memberProps} img={img} key={memberProps.name} />
-          ))}
-        </div>
+        <TeamMembers teamData={teamData} />
 
         <Hr />
 

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Img from 'gatsby-image';
 import { graphql, Link } from 'gatsby';
 import { withI18n, Trans } from '@lingui/react';
@@ -30,34 +30,38 @@ const TeamMember = withI18n()(
   |}) => {
     const ProfileImage = <Img {...img} className="mx-auto" alt={name} />;
     return (
-      <div className="col-12 col-md-6 col-lg-4 ledgista-profile">
-        <div className="h-100 pb-6">
-          {article ? (
-            <Link href to={`/updates/${article}/`}>
-              {ProfileImage}
-            </Link>
-          ) : (
-            ProfileImage
-          )}
-          <div className="ledgista-text text-center d-flex flex-column align-items-center justify-content-between">
-            <div>
-              <h4 className="mt-2 mb-0">{name}</h4>
-              <small className="text-muted">{role}</small>
-              <p className="mt-2 font-weight-light">{description}</p>
-            </div>
-            <div>
-              <a className="social-icon mr-3" href={`mailto:${mail}`}>
-                <FontAwesomeIcon icon={faEnvelope} />
-              </a>
-              {twitter && (
-                <a className="social-icon mr-3" href={twitter}>
-                  <FontAwesomeIcon icon={faTwitter} />
-                </a>
+      <div className="ledgista col-12 col-md-6 col-lg-4">
+        <div className="pb-6 h-100 d-flex flex-column align-items-center justify-content-between">
+          <div className="d-flex flex-column align-items-center">
+            <div className="ledgista-image-wrapper">
+              {article ? (
+                <Link href to={`/updates/${article}/`}>
+                  {ProfileImage}
+                </Link>
+              ) : (
+                ProfileImage
               )}
-              <a className="social-icon" href={linkedIn}>
-                <FontAwesomeIcon icon={faLinkedin} />
-              </a>
             </div>
+            <div className="text-center d-flex flex-column align-items-center">
+              <div>
+                <h4 className="mt-2 mb-0">{name}</h4>
+                <small className="text-muted">{role}</small>
+                <p className="mt-2 font-weight-light">{description}</p>
+              </div>
+            </div>
+          </div>
+          <div>
+            <a className="social-icon mr-3" href={`mailto:${mail}`}>
+              <FontAwesomeIcon icon={faEnvelope} />
+            </a>
+            {twitter && (
+              <a className="social-icon mr-3" href={twitter}>
+                <FontAwesomeIcon icon={faTwitter} />
+              </a>
+            )}
+            <a className="social-icon" href={linkedIn}>
+              <FontAwesomeIcon icon={faLinkedin} />
+            </a>
           </div>
         </div>
       </div>
@@ -86,7 +90,7 @@ const IndexPage = (props: Props) => {
   const team = getWholeTeam(props.prefix);
   const title = i18n.t`About us`;
   const description = i18n.t`We believe that entrepreneurship is the main driver of positive change in the world. That is why we build beautiful and intuitive software for startups, helping them be more successful`;
-  const [teamArray, setTeamArray] = useState([
+  const teamArray = shuffleArray([
     [team.timo, data.timo],
     [team.yoko, data.yoko],
     [team.ben, data.ben],
@@ -102,10 +106,6 @@ const IndexPage = (props: Props) => {
     [team.mariana, data.mariana],
     [team.luna, data.luna],
   ]);
-
-  useEffect(() => {
-    setTeamArray((prev) => shuffleArray(prev));
-  }, []);
 
   return (
     <div>

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -54,10 +54,12 @@ const TeamMember = withI18n()(
             <a className="social-icon mr-3" href={`mailto:${mail}`}>
               <FontAwesomeIcon icon={faEnvelope} />
             </a>
-            {twitter && (
+            {twitter ? (
               <a className="social-icon mr-3" href={twitter}>
                 <FontAwesomeIcon icon={faTwitter} />
               </a>
+            ) : (
+              <span />
             )}
             <a className="social-icon" href={linkedIn}>
               <FontAwesomeIcon icon={faLinkedin} />

--- a/src/pages/about-us.jsx
+++ b/src/pages/about-us.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Img from 'gatsby-image';
 import { graphql, Link } from 'gatsby';
 import { withI18n, Trans } from '@lingui/react';
@@ -86,7 +86,7 @@ const IndexPage = (props: Props) => {
   const team = getWholeTeam(props.prefix);
   const title = i18n.t`About us`;
   const description = i18n.t`We believe that entrepreneurship is the main driver of positive change in the world. That is why we build beautiful and intuitive software for startups, helping them be more successful`;
-  const teamArray = shuffleArray([
+  const [teamArray, setTeamArray] = useState([
     [team.timo, data.timo],
     [team.yoko, data.yoko],
     [team.ben, data.ben],
@@ -102,6 +102,10 @@ const IndexPage = (props: Props) => {
     [team.mariana, data.mariana],
     [team.luna, data.luna],
   ]);
+
+  useEffect(() => {
+    setTeamArray((prev) => shuffleArray(prev));
+  }, []);
 
   return (
     <div>

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -389,15 +389,12 @@ $deco-dot-size: 8px;
 }
 
 // About
-.ledgista-profile {
-  .gatsby-image-wrapper {
-    max-width: 245px;
+.ledgista {
+  .ledgista-image-wrapper {
+    width: 245px;
   }
   .social-icon {
     font-size: 20px;
-  }
-  .ledgista-text {
-    height: calc(100% - 245px);
   }
 }
 


### PR DESCRIPTION
- We recently implemented an array shuffling fn to randomize team member order in every render of the about us page
- In production, hard-refreshing would cause 2 bugs: some images would randomly enlarge, and the social icons would randomly move to other people 🤷🏻‍♂️
- The fix for the images was to avoid using a css `calc` fn to calculate the size of the container
- The fix for the icon shuffling was to keep the data in a component's state, and shuffle it in a `useEffect`