### PR TITLE
LG-2812/improveGetDemoUX

### DIFF
--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -94,5 +94,5 @@ declare type FormStatus =
   | 'invalid-email'
   | 'invalid-fields'
   | 'invalid-required-fields'
-  | 'error'
+  | 'fetch-error'
   | 'submitted';

--- a/src/components/forms/DemoForm.jsx
+++ b/src/components/forms/DemoForm.jsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Input, InvalidFieldHints } from './Fields';
 import { handleDemoSubmit, type RequesterType, COMPANY, INVESTOR } from './lib';
 
-const { IDLE, ERROR } = FORM_STATUSES;
+const { IDLE, FETCH_ERROR } = FORM_STATUSES;
 
 const REQUESTER_TYPES = [COMPANY, INVESTOR];
 
@@ -28,7 +28,7 @@ export const DemoForm = ({
   const [formStatus, setFormStatus] = useState(IDLE);
   const inputClassName = 'height-42px bg-transparent text-white placeholder-white';
   const values = { requesterType, email, size };
-  const isButtonDisabled = formStatus !== IDLE && formStatus !== ERROR;
+  const isButtonDisabled = formStatus !== IDLE && formStatus !== FETCH_ERROR;
 
   return (
     <div className="d-flex flex-column align-items-center border border-gray-neutral p-2 p-sm-4 ml-lg-4 mt-lg-4 rounded">

--- a/src/components/forms/DemoForm.jsx
+++ b/src/components/forms/DemoForm.jsx
@@ -7,7 +7,7 @@ import { Button } from '../Button';
 import { Input, InvalidFieldHints } from './Fields';
 import { handleDemoSubmit, type RequesterType, COMPANY, INVESTOR } from './lib';
 
-const { IDLE } = FORM_STATUSES;
+const { IDLE, ERROR } = FORM_STATUSES;
 
 const REQUESTER_TYPES = [COMPANY, INVESTOR];
 
@@ -28,6 +28,7 @@ export const DemoForm = ({
   const [formStatus, setFormStatus] = useState(IDLE);
   const inputClassName = 'height-42px bg-transparent text-white placeholder-white';
   const values = { requesterType, email, size };
+  const isButtonDisabled = formStatus !== IDLE && formStatus !== ERROR;
 
   return (
     <div className="d-flex flex-column align-items-center border border-gray-neutral p-2 p-sm-4 ml-lg-4 mt-lg-4 rounded">
@@ -82,7 +83,7 @@ export const DemoForm = ({
           type="number"
         />
         <Button
-          disabled={formStatus !== IDLE}
+          disabled={isButtonDisabled}
           type="submit"
           cta
           className="w-100 mx-1 mt-4 mb-4 align-self-center btn-xl"

--- a/src/components/forms/Fields.jsx
+++ b/src/components/forms/Fields.jsx
@@ -46,13 +46,13 @@ export const InvalidFieldHints = ({
   formStatus: FormStatus,
   className?: string,
 }) => {
-  const { INVALID_FIELDS, INVALID_REQUIRED_FIELDS, INVALID_EMAIL, ERROR } = FORM_STATUSES;
+  const { INVALID_FIELDS, INVALID_REQUIRED_FIELDS, INVALID_EMAIL, FETCH_ERROR } = FORM_STATUSES;
   return (
     <small className={`text-danger form-error-message ${className}`}>
       {formStatus === INVALID_FIELDS && <Trans>Please fill in all fields</Trans>}
       {formStatus === INVALID_REQUIRED_FIELDS && <Trans>* Please fill in required fields</Trans>}
       {formStatus === INVALID_EMAIL && <Trans>Oops. This email address is invalid.</Trans>}
-      {formStatus === ERROR && <Trans>Something went wrong, please try again.</Trans>}
+      {formStatus === FETCH_ERROR && <Trans>Something went wrong, please try again.</Trans>}
     </small>
   );
 };

--- a/src/components/forms/SubscriptionForm.jsx
+++ b/src/components/forms/SubscriptionForm.jsx
@@ -12,7 +12,7 @@ import { Button } from '../Button';
 import { signupOnMixpanel, trackOnMixpanel } from './lib';
 import { InvalidFieldHints } from './Fields';
 
-const { ERROR, IDLE, INVALID_EMAIL, LOADING } = FORM_STATUSES;
+const { FETCH_ERROR, IDLE, INVALID_EMAIL, LOADING } = FORM_STATUSES;
 
 export class SubscriptionForm extends Component<
   {| i18n: I18n, toggle?: () => void, trackingEvent: string |},
@@ -36,10 +36,10 @@ export class SubscriptionForm extends Component<
           if (this.props.toggle) this.props.toggle();
           navigate('/subscribed');
         } else {
-          this.setState({ status: ERROR });
+          this.setState({ status: FETCH_ERROR });
         }
       } catch (error) {
-        this.setState({ status: ERROR });
+        this.setState({ status: FETCH_ERROR });
       }
     } else {
       this.setState({ status: INVALID_EMAIL });
@@ -50,7 +50,7 @@ export class SubscriptionForm extends Component<
     const { status } = state;
     const { i18n } = props;
     const invalid = status === INVALID_EMAIL;
-    const error = status === ERROR;
+    const error = status === FETCH_ERROR;
     const loading = status === LOADING;
     return (
       <>

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -81,7 +81,9 @@ export const handleDemoSubmit = async ({
 
   const response = await submitToHubspot(parsedFormValues);
   if (response.status !== 200) {
-    setFormStatus(ERROR);
+    setTimeout(() => {
+      setFormStatus(ERROR);
+    }, 1000);
     throw new Error(response.statusText);
   }
 

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -18,7 +18,7 @@ import {
   smallCompanyUrl,
 } from './constants';
 
-const { INVALID_EMAIL, INVALID_FIELDS, LOADING, SUBMITTED, ERROR } = FORM_STATUSES;
+const { INVALID_EMAIL, INVALID_FIELDS, LOADING, SUBMITTED, FETCH_ERROR } = FORM_STATUSES;
 
 const isDeerCompany = (size: number) => size >= DEER_COMPANY_THRESHOLD;
 const isSmallCompany = (size: number) =>
@@ -82,7 +82,7 @@ export const handleDemoSubmit = async ({
   const response = await submitToHubspot(parsedFormValues);
   if (response.status !== 200) {
     setTimeout(() => {
-      setFormStatus(ERROR);
+      setFormStatus(FETCH_ERROR);
     }, 1000);
     throw new Error(response.statusText);
   }

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -59,7 +59,7 @@ export const MIXPANEL_TOKEN = isNetlify
 export const FORM_STATUSES = Object.freeze({
   IDLE: 'idle',
   LOADING: 'loading',
-  ERROR: 'error',
+  FETCH_ERROR: 'fetch-error',
   SUBMITTED: 'submitted',
   INVALID_EMAIL: 'invalid-email',
   INVALID_FIELDS: 'invalid-fields',


### PR DESCRIPTION
In the demo form (ledgy.com/demo/ledgy), if the response from hubspot is not a `200` we display an error message telling the user that something went wrong, and to try again. The issue is that the submit button is disabled, and the user doesn't know that to enable it he/she has to change something in the form to reset its state to `IDLE`

So, this PR
- Allows resubmitting the `DemoForm` after 1 second if a `fetch` error is encountered (without the need to update anything in the form to reset its state)