### PR TITLE
Unthrow error when unvalid email in demo request

### DIFF
--- a/src/components/forms/DemoForm.jsx
+++ b/src/components/forms/DemoForm.jsx
@@ -95,3 +95,4 @@ export const DemoForm = ({
     </div>
   );
 };
+

--- a/src/components/forms/DemoForm.jsx
+++ b/src/components/forms/DemoForm.jsx
@@ -95,4 +95,3 @@ export const DemoForm = ({
     </div>
   );
 };
-

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -16,7 +16,19 @@ import {
   smallCompanyUrl,
 } from './constants';
 
+type Error = {
+  errorType: string,
+  message: string,
+};
+
+type JsonResponse = {
+  errors: Error[],
+};
+
 const { INVALID_EMAIL, INVALID_FIELDS, LOADING, SUBMITTED, FETCH_ERROR } = FORM_STATUSES;
+
+const isInvalidEmailError = (errors: Error[]): boolean =>
+  errors.find((error) => error.errorType === 'INVALID_EMAIL');
 
 const isDeerCompany = (size: number) => size >= DEER_COMPANY_THRESHOLD;
 const isFund = (size: number) => size >= FUND_INVESTMENT_THRESHOLD;
@@ -75,17 +87,15 @@ export const handleDemoSubmit = async ({
   const parsedFormValues = { isCompany, email, size, value };
 
   const response = await submitToHubspot(parsedFormValues);
-  if (response.status === 400) {
-    setTimeout(() => {
-      setFormStatus(INVALID_EMAIL);
-    }, 1000);
-    return;
-  }
 
   if (response.status !== 200) {
-    setTimeout(() => {
-      setFormStatus(FETCH_ERROR);
-    }, 1000);
+    const jsonResponse: JsonResponse = await response.json();
+    if (isInvalidEmailError(jsonResponse.errors)) {
+      setTimeout(() => {
+        setFormStatus(INVALID_EMAIL);
+      }, 1000);
+      return;
+    }
     throw new Error(response.statusText);
   }
 

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -96,6 +96,10 @@ export const handleDemoSubmit = async ({
       }, 1000);
       return;
     }
+    setTimeout(() => {
+      setFormStatus(FETCH_ERROR);
+    }, 1000);
+    // TODO: replace with send to sentry helper `error(response.statusText)`
     throw new Error(response.statusText);
   }
 

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -16,18 +16,18 @@ import {
   smallCompanyUrl,
 } from './constants';
 
-type Error = {
+type ErrorResponse = {
   errorType: string,
   message: string,
 };
 
 type JsonResponse = {
-  errors: Error[],
+  errors: ErrorResponse[],
 };
 
 const { INVALID_EMAIL, INVALID_FIELDS, LOADING, SUBMITTED, FETCH_ERROR } = FORM_STATUSES;
 
-const isInvalidEmailError = (errors: Error[]): boolean =>
+const isInvalidEmailError = (errors: ErrorResponse[]): boolean =>
   errors.some((error) => error.errorType === 'INVALID_EMAIL');
 
 const isDeerCompany = (size: number) => size >= DEER_COMPANY_THRESHOLD;

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -28,7 +28,7 @@ type JsonResponse = {
 const { INVALID_EMAIL, INVALID_FIELDS, LOADING, SUBMITTED, FETCH_ERROR } = FORM_STATUSES;
 
 const isInvalidEmailError = (errors: Error[]): boolean =>
-  errors.find((error) => error.errorType === 'INVALID_EMAIL');
+  errors.some((error) => error.errorType === 'INVALID_EMAIL');
 
 const isDeerCompany = (size: number) => size >= DEER_COMPANY_THRESHOLD;
 const isFund = (size: number) => size >= FUND_INVESTMENT_THRESHOLD;

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -75,6 +75,13 @@ export const handleDemoSubmit = async ({
   const parsedFormValues = { isCompany, email, size, value };
 
   const response = await submitToHubspot(parsedFormValues);
+  if (response.status === 400) {
+    setTimeout(() => {
+      setFormStatus(INVALID_EMAIL);
+    }, 1000);
+    return;
+  }
+
   if (response.status !== 200) {
     setTimeout(() => {
       setFormStatus(FETCH_ERROR);

--- a/src/components/forms/lib/handleDemoSubmit.js
+++ b/src/components/forms/lib/handleDemoSubmit.js
@@ -91,9 +91,7 @@ export const handleDemoSubmit = async ({
   if (response.status !== 200) {
     const jsonResponse: JsonResponse = await response.json();
     if (isInvalidEmailError(jsonResponse.errors)) {
-      setTimeout(() => {
-        setFormStatus(INVALID_EMAIL);
-      }, 1000);
+      setFormStatus(INVALID_EMAIL);
       return;
     }
     setTimeout(() => {


### PR DESCRIPTION
*invalid, not unvalid.

Instead of throwing an error when an invalid email address is given in the Demo form, we send a meaningful message to the user:

![Screenshot from 2020-11-06 11-51-07](https://user-images.githubusercontent.com/73158906/98358136-8957a280-2026-11eb-9193-7a0fab7d3460.png)
