### PR TITLE
use NetworkFirst for app-data and page-data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -94,6 +94,25 @@ module.exports = {
       },
     },
     { resolve: 'gatsby-plugin-netlify-cache', options: { cachePublic: true } },
-    'gatsby-plugin-offline',
+    {
+      resolve: `gatsby-plugin-offline`,
+      options: {
+        workboxConfig: {
+          runtimeCaching: [
+            { urlPattern: /(\.js$|\.css$|static\/)/, handler: `CacheFirst` },
+            { urlPattern: /^https?:.*\/page-data\/.*\.json/, handler: `NetworkFirst` },
+            { urlPattern: /^https?:.*\/app-data\/.*\.json/, handler: `NetworkFirst` },
+            {
+              urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+              handler: `StaleWhileRevalidate`,
+            },
+            {
+              urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+              handler: `StaleWhileRevalidate`,
+            },
+          ],
+        },
+      },
+    },
   ],
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -101,7 +101,6 @@ module.exports = {
           runtimeCaching: [
             { urlPattern: /(\.js$|\.css$|static\/)/, handler: `CacheFirst` },
             { urlPattern: /^https?:.*\/page-data\/.*\.json/, handler: `NetworkFirst` },
-            { urlPattern: /^https?:.*\/app-data\/.*\.json/, handler: `NetworkFirst` },
             {
               urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
               handler: `StaleWhileRevalidate`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,10 +1124,18 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@contentful/rich-text-react-renderer": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-14.1.2.tgz",
+      "integrity": "sha512-UmZ5nNvFXuD4LA2TKDDD52FgzmeMAQUVu5p9UqKDVDG6twHAD4DiWtoXSRM5Bebftlx2UH+UeWHbxIOgF/lV5A==",
+      "requires": {
+        "@contentful/rich-text-types": "^14.1.2"
+      }
+    },
     "@contentful/rich-text-types": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-14.1.1.tgz",
-      "integrity": "sha512-Iow9U3so7V+2AngYLmt42BGtHjHGl+DQpxvXaryJe1X9LPHrQ41pALztJZFzDgajoEswBjOgmI9CFeQ1oUAdJA=="
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-14.1.2.tgz",
+      "integrity": "sha512-XbgZ7op5uyYYszipgQg/bYobF4b+llXyTwS8hISRniQY9xKESz544eP2OGmRc4J3MHx29M7Vmx7TVA/IK65giQ=="
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -2646,6 +2654,31 @@
         }
       }
     },
+    "@sideway/address": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
+      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+        }
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2695,6 +2728,11 @@
       "requires": {
         "defer-to-connect": "^1.0.1"
       }
+    },
+    "@tokenizer/token": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
+      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -2927,6 +2965,15 @@
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
           "integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
         }
+      }
+    },
+    "@types/readable-stream": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
+      "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
+      "requires": {
+        "@types/node": "*",
+        "safe-buffer": "*"
       }
     },
     "@types/responselike": {
@@ -6144,15 +6191,39 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "contentful": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.14.6.tgz",
-      "integrity": "sha512-7/Xqw/UT0/zW9DeVGAwtW4twGbThIc6rbLATrhUn7AXt/xTCFzgPiJxHgRU9gmr733q/Wckv663B51abDMS9Nw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-7.15.0.tgz",
+      "integrity": "sha512-OHadDyccv3dkCUMzK0iGEbIGbjY4aPyQJVtbKUtqAuzuxTt5WOhU64gZANrwFklY7Jl3c9NuluHXMwd8YRmBng==",
       "requires": {
-        "axios": "^0.19.1",
-        "contentful-resolve-response": "^1.2.2",
-        "contentful-sdk-core": "^6.4.5",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.11"
+        "axios": "^0.20.0",
+        "contentful-resolve-response": "^1.3.0",
+        "contentful-sdk-core": "^6.5.0",
+        "fast-copy": "^2.1.0",
+        "json-stringify-safe": "^5.0.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.20.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+          "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+          "requires": {
+            "follow-redirects": "^1.10.0"
+          }
+        },
+        "contentful-sdk-core": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.5.0.tgz",
+          "integrity": "sha512-n9VfjFrwH9ACO0qHE9YYiFW1dO5knVoqnRA+hZIH5cgm7hpMKZgIbbzEvODCGlEajBEhNx80sfwrdTD1ityklw==",
+          "requires": {
+            "fast-copy": "^2.1.0",
+            "qs": "^6.5.2"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+          "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+        }
       }
     },
     "contentful-management": {
@@ -6174,11 +6245,11 @@
       }
     },
     "contentful-resolve-response": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.2.2.tgz",
-      "integrity": "sha512-KyRz05f2YFJDSFs/L5jtsptbL5Fk3+ukSjRF94zFXq0FOtYoaxyCbqKgHhK2+3hlipxVQ+KGRus/tSaD6PoPMg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.0.tgz",
+      "integrity": "sha512-FFa4it5VXW1YGyim5rhPbnwmN4c8OcmkpLrsylTL2Y1YpoC+6qnZSSU/QZyvHomLdEgwXaSXhGVJkWjpdz5IMg==",
       "requires": {
-        "lodash": "^4.17.15"
+        "fast-copy": "^2.1.0"
       }
     },
     "contentful-sdk-core": {
@@ -8950,6 +9021,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-copy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.0.tgz",
+      "integrity": "sha512-j4VxAVJsu9NHveYrIj0+nJxXe2lOlibKTlyy0jH8DBwcuV6QyXTy0zTqZhmMKo7EYvuaUk/BFj/o6NU6grE5ag=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10619,6 +10695,14 @@
         }
       }
     },
+    "gatsby-plugin-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-0.4.0.tgz",
+      "integrity": "sha512-yxDzKcEmZc0whi/d+2appWVhqhrpWfFAPRO0pjIszCEgaeqybUB2lSL6Hx5r36W4Ff1INQ0A/WfPOJETLY+O2A==",
+      "requires": {
+        "joi": "^17.2.1"
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.0.14.tgz",
@@ -11335,28 +11419,39 @@
       }
     },
     "gatsby-source-contentful": {
-      "version": "2.3.50",
-      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-2.3.50.tgz",
-      "integrity": "sha512-LsgFk3Hjg24ynZMWk2xWSbXh3LfLuzLN9xUA3/K9PQYh8Ly6BAYsI5NxXzsfCc/DuV/mRyU2NC1elwtcqiZ2gg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/gatsby-source-contentful/-/gatsby-source-contentful-4.1.1.tgz",
+      "integrity": "sha512-lehKMO+gM9t41HghhZZfKI2VVDw3BWrF76Wouv7zHozRRKtKek3VSwgvynHwNMkf42TSHvJRb2Sher+pAElxTA==",
       "requires": {
-        "@babel/runtime": "^7.11.2",
-        "@contentful/rich-text-types": "^14.1.1",
+        "@babel/runtime": "^7.12.5",
+        "@contentful/rich-text-react-renderer": "^14.1.2",
+        "@contentful/rich-text-types": "^14.1.2",
         "@hapi/joi": "^15.1.1",
-        "axios": "^0.20.0",
+        "axios": "^0.21.0",
         "base64-img": "^1.0.4",
         "bluebird": "^3.7.2",
         "chalk": "^4.1.0",
-        "contentful": "^7.14.6",
+        "contentful": "^7.14.12",
         "fs-extra": "^9.0.1",
-        "gatsby-core-utils": "^1.3.23",
-        "gatsby-source-filesystem": "^2.3.33",
-        "is-online": "^8.4.0",
+        "gatsby-core-utils": "^1.5.0",
+        "gatsby-plugin-utils": "^0.4.0",
+        "gatsby-source-filesystem": "^2.6.1",
+        "is-online": "^8.5.1",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.20",
+        "node-fetch": "^2.6.1",
         "progress": "^2.0.3",
         "qs": "^6.9.4"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -11366,9 +11461,9 @@
           }
         },
         "axios": {
-          "version": "0.20.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
-          "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+          "version": "0.21.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+          "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
           "requires": {
             "follow-redirects": "^1.10.0"
           }
@@ -11395,6 +11490,17 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "file-type": {
+          "version": "16.0.1",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.0.1.tgz",
+          "integrity": "sha512-rwXqMZiizJd0uXZE52KN2DtPBAV99qz9cUTHHt8pSyaQzgVYrHJGR0qt2p4N/yzHEL/tGrlB/TgawQb4Fnxxyw==",
+          "requires": {
+            "readable-web-to-node-stream": "^3.0.0",
+            "strtok3": "^6.0.3",
+            "token-types": "^2.0.0",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
         "follow-redirects": {
           "version": "1.13.0",
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
@@ -11412,9 +11518,9 @@
           }
         },
         "gatsby-core-utils": {
-          "version": "1.3.23",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.3.23.tgz",
-          "integrity": "sha512-H6n6dDeRZ22HAJaBUIt5YjB/BSaE8Jq+kayMUv/YzL1RL2yFZ5lqcLwIL1OE2vWk1mQjMUBZCRxLODU0q1i3bQ==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.5.0.tgz",
+          "integrity": "sha512-hCt44m7I9Kmra/iVJwrmHXK8WFK9I1JwXQZquIVZ/JaG8UgqroxW1wpsY7ColbHGMATOmp13Efqn02VNPnms5Q==",
           "requires": {
             "ci-info": "2.0.0",
             "configstore": "^5.0.1",
@@ -11451,23 +11557,21 @@
           }
         },
         "gatsby-source-filesystem": {
-          "version": "2.3.33",
-          "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.33.tgz",
-          "integrity": "sha512-7ikBtroC/X/oe7wJn54E4X588HvIyQmgyoDsS+TBsP64C7yIt/bnra8ssE2dyywtY+bMg8vVJX82F9oQumRbLQ==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.6.1.tgz",
+          "integrity": "sha512-XQvQewST3uH8bDjyLMv5srqc0Hh1eIzVkPLMXpcWoszlUX/MSCdY8+boZjLAx8YK0O65MLCr66sV9qFDBldjAw==",
           "requires": {
-            "@babel/runtime": "^7.11.2",
+            "@babel/runtime": "^7.12.5",
             "better-queue": "^3.8.10",
-            "bluebird": "^3.7.2",
             "chokidar": "^3.4.2",
-            "file-type": "^12.4.2",
+            "file-type": "^16.0.0",
             "fs-extra": "^8.1.0",
-            "gatsby-core-utils": "^1.3.23",
+            "gatsby-core-utils": "^1.5.0",
             "got": "^9.6.0",
-            "md5-file": "^3.2.3",
+            "md5-file": "^5.0.0",
             "mime": "^2.4.6",
             "pretty-bytes": "^5.4.1",
             "progress": "^2.0.3",
-            "read-chunk": "^3.2.0",
             "valid-url": "^1.0.9",
             "xstate": "^4.13.0"
           },
@@ -11521,18 +11625,40 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
           "requires": {
             "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
+            "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+            }
           }
+        },
+        "md5-file": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-5.0.0.tgz",
+          "integrity": "sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw=="
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "qs": {
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
           "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
         },
         "supports-color": {
           "version": "7.2.0",
@@ -13915,9 +14041,9 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
     },
     "is-online": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/is-online/-/is-online-8.4.0.tgz",
-      "integrity": "sha512-i0qGRbtUaQEU5Z7O3LmOnH3yorhG1lnygqY2cv3InlQKKm3nx6XiGXZk49lATR3N7hyxoiuHMR0pKwRuB+s5lg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/is-online/-/is-online-8.5.1.tgz",
+      "integrity": "sha512-RKyTQx/rJqw2QOXHwy7TmXdlkpe0Hhj7GBsr6TQJaj4ebNOfameZCMspU5vYbwBBzJ2brWArdSvNVox6T6oCTQ==",
       "requires": {
         "got": "^9.6.0",
         "p-any": "^2.0.0",
@@ -14368,6 +14494,33 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "dev": true
+    },
+    "joi": {
+      "version": "17.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
+      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.0",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
+          "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
+      }
     },
     "jpeg-js": {
       "version": "0.4.2",
@@ -17776,6 +17929,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "peek-readable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.0.tgz",
+      "integrity": "sha512-KGuODSTV6hcgdZvDrIDBUkN0utcAVj1LL7FfGbM0viKTtCHmtZcuEJ+lGqsp0fTFkGqesdtemV2yUSMeyy3ddA=="
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -19706,6 +19864,27 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.0.tgz",
+      "integrity": "sha512-HNmLb3n0SteGAs8HQlErYPGeO+y7cvL/mVUKtXeUkl0iCZ/2GIgKGrCFHyS7UXFnO8uc9U+0y3pYIzAPsjFfvA==",
+      "requires": {
+        "@types/readable-stream": "^2.3.9",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "readdir-scoped-modules": {
@@ -22134,6 +22313,23 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "strtok3": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
+      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
+      "requires": {
+        "@tokenizer/token": "^0.1.1",
+        "@types/debug": "^4.1.5",
+        "peek-readable": "^3.1.0"
+      },
+      "dependencies": {
+        "@types/debug": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+          "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+        }
+      }
+    },
     "style-loader": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.23.1.tgz",
@@ -22672,6 +22868,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "token-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-2.0.0.tgz",
+      "integrity": "sha512-WWvu8sGK8/ZmGusekZJJ5NM6rRVTTDO7/bahz4NGiSDb/XsmdYBn6a1N/bymUHuWYTWeuLUg98wUzvE4jPdCZw==",
+      "requires": {
+        "@tokenizer/token": "^0.1.0",
+        "ieee754": "^1.1.13"
+      }
     },
     "toposort": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gatsby-remark-katex": "3.3.12",
     "gatsby-remark-prismjs": "3.5.13",
     "gatsby-remark-unwrap-images": "1.0.2",
-    "gatsby-source-contentful": "2.3.50",
+    "gatsby-source-contentful": "4.1.1",
     "gatsby-source-filesystem": "2.3.30",
     "gatsby-transformer-sharp": "2.5.15",
     "isomorphic-fetch": "2.2.1",


### PR DESCRIPTION
Change default config of `gatsby-plugin-offline` to load `page-data` from `StaleWhileRevalidate` to a `NetworkFirst` strategy:
https://github.com/gatsbyjs/gatsby/blob/2b8fe1223c49b7cb2bc28d04a79c60bf7c9221a1/packages/gatsby-plugin-offline/src/gatsby-node.js#L134