### PR TITLE
Lg 3513/add margin

### DIFF
--- a/src/components/markdown/LongText.tsx
+++ b/src/components/markdown/LongText.tsx
@@ -38,7 +38,7 @@ export const LongText = ({
 }) => {
   const components = getProviderComponents(prefix);
   return (
-    <div className="d-flex justify-content-center">
+    <div className="d-flex justify-content-center mb-5">
       <div className={`${isMarkdown ? 'markdown' : ''} ${className}`}>
         {content && (
           <MDXProvider components={components}>


### PR DESCRIPTION
On calculator page, add a small margin between the content and the footer:

### before
![Screenshot from 2021-02-17 16-22-17](https://user-images.githubusercontent.com/39551291/108225612-61ef9600-713c-11eb-9fcc-99cfb50e628e.png)

### after
![Screenshot from 2021-02-17 16-22-26](https://user-images.githubusercontent.com/39551291/108225621-6451f000-713c-11eb-888e-e8519a3489e6.png)
