### PR TITLE
make link and checklist length flexible

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -37,11 +37,26 @@ exports.onCreatePage = async ({ page, actions }) => {
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
   const typeDefinitions = `
+  type Body implements Node  {
+    body: String
+  }
+  type Mdx implements Node  {
+    childMdx: Body
+  }
+  type ContentfulChecklistWithScreenshot implements Node {
+    description: String
+    checklist: [String]
+    longDescription: Mdx
+  }
   type ContentfulCallToAction2021 implements Node {
     linkText: String
     linkUrl: String
   }
   type ContentfulTestimonialCardBuildingBlock implements Node {
+    linkText: String
+    linkUrl: String
+  }
+  type ContentfulContentWithChecklist implements Node {
     linkText: String
     linkUrl: String
   }

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -126,9 +126,12 @@ declare type TopBannerProps = Id & {
 declare type ChecklistWithScreenshotProps = Id & {
   __typename: 'ContentfulChecklistWithScreenshot';
   header: string;
-  description: string;
+  description?: string;
+  longDescription?: Mdx;
   image: ImageProps;
-  checklist: string[];
+  checklist?: string[];
+  smallImage: boolean;
+  inverted: boolean;
 };
 
 declare type MainPageEntryProps = TopBannerProps | EntryProps;

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -75,8 +75,8 @@ declare type ContentWithChecklistProps = Id & {
   __typename: 'ContentfulContentWithChecklist';
   header: string;
   description: string;
-  linkText: string;
-  linkUrl: string;
+  linkText?: string;
+  linkUrl?: string;
   checklist: string[];
 };
 

--- a/src/components/ChecklistWithScreenshot.tsx
+++ b/src/components/ChecklistWithScreenshot.tsx
@@ -29,12 +29,16 @@ export const ChecklistWithScreenshot = ({
         <div
           className={`${order} col-lg-${textCol} pr-4 d-flex flex-column justify-content-center`}
         >
-          <p className={`text-deep-blue my-2 my-lg-0 ${isLongChecklist ? 'mb-2 mb-xl-3' : 'mb-4'}`}>
-            {!!description && <DynamicTrans>{description}</DynamicTrans>}
+          <div className="text-deep-blue my-2 my-lg-0">
+            {!!description && (
+              <p className={`${isLongChecklist ? 'mb-2 mb-xl-3' : 'mb-4'}`}>
+                <DynamicTrans>{description}</DynamicTrans>
+              </p>
+            )}
             {!!longDescription && !description && (
               <MDXRenderer>{longDescription.childMdx.body}</MDXRenderer>
             )}
-          </p>
+          </div>
           {withChecklist && (
             <ul className="my-2 pl-0">
               {checklist.map((item) => {

--- a/src/components/ChecklistWithScreenshot.tsx
+++ b/src/components/ChecklistWithScreenshot.tsx
@@ -5,48 +5,65 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { CustomFade, DynamicTrans, Section, SectionHeader } from './utils';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
 
 export const ChecklistWithScreenshot = ({
   header,
   description,
-  checklist,
+  longDescription,
+  checklist = [],
   image,
-  mirrored = false,
-}: ChecklistWithScreenshotProps & { mirrored?: boolean }) => {
+  inverted,
+  smallImage,
+}: ChecklistWithScreenshotProps) => {
   const { childImageSharp } = image.localFile || {};
-  const order = mirrored ? 'order-last' : '';
-  const isLongChecklist = checklist.length > 3;
+  const order = inverted ? 'order-last' : '';
+  const withChecklist = !!checklist;
+  const isLongChecklist = withChecklist ? checklist.length > 3 : false;
+  const smallImageCol = smallImage ? 5 : 5;
+  const textCol = 12 - smallImageCol;
+
+  console.log({ description });
   return (
     <Section>
       <SectionHeader header={header} />
-      <div className="row">
-        <div className={`${order} col-lg-4 pr-4 d-flex flex-column justify-content-center`}>
-          <p className={`text-deep-blue ${isLongChecklist ? 'mb-2 mb-xl-3' : 'mb-4'}`}>
-            <DynamicTrans>{description}</DynamicTrans>
+      <div className={`row ${inverted ? 'pl-lg-3' : ''}`}>
+        <div
+          className={`${order} col-lg-${textCol} pr-4 d-flex flex-column justify-content-center`}
+        >
+          <p className={`text-deep-blue my-2 my-lg-0 ${isLongChecklist ? 'mb-2 mb-xl-3' : 'mb-4'}`}>
+            {!!description && <DynamicTrans>{description}</DynamicTrans>}
+            {!!longDescription && !description && (
+              <MDXRenderer>{longDescription.childMdx.body}</MDXRenderer>
+            )}
           </p>
-          <ul className="my-2 pl-0">
-            {checklist.map((item) => {
-              return (
-                <li
-                  key={item}
-                  className={`media d-flex align-items-center ${isLongChecklist ? 'mb-2' : 'mb-3'}`}
-                >
-                  <FontAwesomeIcon
-                    icon={faCheck}
-                    className={`icon mr-3 text-light-energetic-blue`}
-                    size="lg"
-                  />
-                  <p className="text-deep-blue mb-0">
-                    <DynamicTrans>{item}</DynamicTrans>
-                  </p>
-                </li>
-              );
-            })}
-          </ul>
+          {withChecklist && (
+            <ul className="my-2 pl-0">
+              {checklist.map((item) => {
+                return (
+                  <li
+                    key={item}
+                    className={`media d-flex align-items-center ${
+                      isLongChecklist ? 'mb-2' : 'mb-3'
+                    }`}
+                  >
+                    <FontAwesomeIcon
+                      icon={faCheck}
+                      className={`icon mr-3 text-light-energetic-blue`}
+                      size="lg"
+                    />
+                    <p className="text-deep-blue mb-0">
+                      <DynamicTrans>{item}</DynamicTrans>
+                    </p>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </div>
-        <div className="col-lg-8 pl-lg-0">
+        <div className={`col-lg-${smallImageCol} pl-lg-0`}>
           <CustomFade translate="0, 100px">
-            <div className="screenshot">{!!childImageSharp && <Img {...childImageSharp} />}</div>
+            <div className={`screenshot`}>{!!childImageSharp && <Img {...childImageSharp} />}</div>
           </CustomFade>
         </div>
       </div>

--- a/src/components/ChecklistWithScreenshot.tsx
+++ b/src/components/ChecklistWithScreenshot.tsx
@@ -20,10 +20,8 @@ export const ChecklistWithScreenshot = ({
   const order = inverted ? 'order-last' : '';
   const withChecklist = !!checklist;
   const isLongChecklist = withChecklist ? checklist.length > 3 : false;
-  const smallImageCol = smallImage ? 5 : 5;
+  const smallImageCol = smallImage ? 5 : 8;
   const textCol = 12 - smallImageCol;
-
-  console.log({ description });
   return (
     <Section>
       <SectionHeader header={header} />
@@ -63,7 +61,7 @@ export const ChecklistWithScreenshot = ({
         </div>
         <div className={`col-lg-${smallImageCol} pl-lg-0`}>
           <CustomFade translate="0, 100px">
-            <div className={`screenshot`}>{!!childImageSharp && <Img {...childImageSharp} />}</div>
+            <div className="screenshot">{!!childImageSharp && <Img {...childImageSharp} />}</div>
           </CustomFade>
         </div>
       </div>

--- a/src/components/ContentWithChecklist.tsx
+++ b/src/components/ContentWithChecklist.tsx
@@ -59,7 +59,9 @@ export const ContentWithChecklist = ({
                 <p>
                   <DynamicTrans>{description}</DynamicTrans>
                 </p>
-                <LinkWithChevron to={linkUrl} text={linkText} prefix={prefix} />
+                {!!linkUrl && !!linkText && (
+                  <LinkWithChevron to={linkUrl} text={linkText} prefix={prefix} />
+                )}
               </div>
             </div>
             <div className="col-md-6">

--- a/src/components/ContentWithChecklist.tsx
+++ b/src/components/ContentWithChecklist.tsx
@@ -53,7 +53,7 @@ export const ContentWithChecklist = ({
       <section ref={sectionRef} className="py-4 py-lg-7">
         <div className="container my-4">
           <div className="row">
-            <div className={`${order} col-md-6 mb-4 mb-md-0`}>
+            <div className={`${order} col-lg-6 mb-4 mb-lg-0`}>
               <div className="d-flex flex-column justify-content-center h-100">
                 <SectionHeader header={header} className="m-0" />
                 <p>
@@ -64,10 +64,10 @@ export const ContentWithChecklist = ({
                 )}
               </div>
             </div>
-            <div className="col-md-6">
+            <div className="col-lg-6">
               <div className="follow-along-line ml-4 d-flex">
                 <span style={{ height: liHeight, transform }} />
-                <ul className="pl-4 pl-md-6 mb-0">
+                <ul className="pl-4 pl-lg-6 mb-0">
                   {checklist.map((point, i) => {
                     const isActive = activeIndex === i;
                     return (

--- a/src/components/utils/SectionHeader.tsx
+++ b/src/components/utils/SectionHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { DynamicTrans } from './DynamicTrans';
+import { dynamicI18n } from '../../helpers';
+import { getUnderlineHtml } from '../lib';
 
 export const SectionHeader = ({
   header,
@@ -8,7 +9,8 @@ export const SectionHeader = ({
   header: string;
   className?: string;
 }) => (
-  <h2 className={`pb-2 mb-md-4 ${className}`}>
-    <DynamicTrans>{header}</DynamicTrans>
-  </h2>
+  <h2
+    className={`pb-2 mb-md-4 custom-underline ${className}`}
+    dangerouslySetInnerHTML={{ __html: getUnderlineHtml(dynamicI18n(header)) }}
+  ></h2>
 );

--- a/src/layouts/featurePage.tsx
+++ b/src/layouts/featurePage.tsx
@@ -15,7 +15,6 @@ const FeaturePage = ({
   };
 }) => {
   const { title, description, graphic, motivationText, entries } = data.contentfulFeaturePage2021;
-  console.log({ data });
   return (
     <div>
       <Title title={dynamicI18n(title)} description={dynamicI18n(description)} />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -169,7 +169,14 @@ export const ContentWithScreenshotFragment = graphql`
     id
     header
     description
+    longDescription {
+      childMdx {
+        body
+      }
+    }
     checklist
+    smallImage
+    inverted
     image {
       localFile {
         childImageSharp {


### PR DESCRIPTION
#### specs
https://ledgy.atlassian.net/browse/LG-3596?atlOrigin=eyJpIjoiNjU2MGFlYTc1MWRlNGQxNmIzYjBhZWM5NjNlMzg0Y2UiLCJwIjoiaiJ9


#### after 
- possible for four checklist (top)
- button optional (top)
- allow longer text (bottom)
- can flip the side (bottom)
- checklist optional (bottom)

![Screenshot from 2021-03-05 16-50-52](https://user-images.githubusercontent.com/39551291/110139347-38d53380-7dd3-11eb-86cf-98313ad335c6.png)



Post-test Todo
- [ ] clean the test components on sustainability page in contentful
- [ ] make sustainability page invisible again in codes
