### PR TITLE
LG-3766 Create Title field for SEO 

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -62,13 +62,16 @@ exports.createSchemaCustomization = ({ actions }) => {
   }
   union EntryProps = ContentfulTopBanner | ContentfulLogoBanner | ContentfulSelectableCardsWithScreenshots | ContentfulFeatureGrid | ContentfulTestimonialCards | ContentfulTitleWithGraphic | ContentfulContentWithChecklist | ContentfulCallToAction2021 | ContentfulChecklistWithScreenshot
   type ContentfulDemoPage2021 implements Node {
+    title: String
     requesterType: String
     content: [EntryProps] @link(by: "id", from: "content___NODE")
   }
   type ContentfulFrontPage2021 implements Node {
+    title: String
     entries: [EntryProps] @link(by: "id", from: "entries___NODE")
   }
   type ContentfulFeaturePage2021 implements Node {
+    title: String
     entries: [EntryProps] @link(by: "id", from: "entries___NODE")
   }
 `;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -74,6 +74,9 @@ exports.createSchemaCustomization = ({ actions }) => {
     title: String
     entries: [EntryProps] @link(by: "id", from: "entries___NODE")
   }
+  type ContentfulCustomerStory implements Node {
+    title: String
+  }
 `;
   createTypes(typeDefinitions);
 };

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -28,6 +28,7 @@ declare type AllContentfulCustomerStoryProps = Id & {
 
 declare type CustomerStoryBaseProps = AllContentfulCustomerStoryProps & {
   title: string;
+  header: string;
   subtitle: string;
   date: string;
 };

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -64,6 +64,7 @@ declare type BaseFeatureProps = Id & {
 
 declare type FeaturePageProps = BaseFeatureProps & {
   slug: string;
+  header: string;
   entries: EntryProps[];
 };
 

--- a/src/components/customerStories/CustomerStoryLink.tsx
+++ b/src/components/customerStories/CustomerStoryLink.tsx
@@ -10,11 +10,11 @@ export const CustomerStoryLink = ({
   customerStory: CustomerStoryBaseProps;
   prefix: string;
 }) => {
-  const { title, subtitle, slug, company } = customerStory;
+  const { header, subtitle, slug, company } = customerStory;
   const { childImageSharp } = company.logo.localFile || {};
   const to = `customer-stories/${slug}`;
   const image = childImageSharp ? <Img {...childImageSharp} /> : null;
-  const cardTitle = <h5>{title}</h5>;
+  const cardTitle = <h5>{header}</h5>;
   return (
     <CardLink
       title={cardTitle}

--- a/src/layouts/customerStory.tsx
+++ b/src/layouts/customerStory.tsx
@@ -14,15 +14,15 @@ const CustomerStory = ({
     allContentfulCustomerStory: { edges: { node: AllContentfulCustomerStoryProps }[] };
   };
 }) => {
-  const { id, title, subtitle, language, content, company } = data.contentfulCustomerStory;
+  const { id, title, header, subtitle, language, content, company } = data.contentfulCustomerStory;
   const otherUserStories = data.allContentfulCustomerStory.edges
     .filter(({ node }) => node.id !== id)
     .map(({ node }) => node);
   const hasOtherCustomerStories = otherUserStories.length > 0;
   return (
     <div>
-      <Title title={title} description={subtitle} />
-      <PageHeader lang={lang} documentLang={language} title={title} subtitle={subtitle} />
+      <Title title={title || header} description={subtitle} />
+      <PageHeader lang={lang} documentLang={language} title={header} subtitle={subtitle} />
       <main>
         <section className="section ">
           <div className="container container-medium">
@@ -61,6 +61,7 @@ export const customerStoryQuery = graphql`
       id
       slug
       title
+      header
       subtitle
       language
       content {

--- a/src/layouts/demo.tsx
+++ b/src/layouts/demo.tsx
@@ -16,6 +16,7 @@ import { DATA_PROTECTION } from '../helpers';
 type DemoPageProps = {
   content: EntryProps[];
   title: string;
+  header: string;
   description: string;
   formButtonText: string;
   requesterType?: RequesterType;
@@ -54,6 +55,7 @@ const DemoPage = (props: Props) => {
   const {
     content,
     title,
+    header,
     description,
     formButtonText,
     requesterType,
@@ -68,11 +70,11 @@ const DemoPage = (props: Props) => {
 
   return (
     <>
-      <Title title={dynamicI18n(title)} description={dynamicI18n(description)} />
+      <Title title={dynamicI18n(title || header)} description={dynamicI18n(description)} />
       <TopBannerLayout
         buttonOne={buttonOne}
         buttonTwo={buttonTwo}
-        title={<DynamicTrans>{title}</DynamicTrans>}
+        title={<DynamicTrans>{header}</DynamicTrans>}
         subtitle={<DynamicTrans>{description}</DynamicTrans>}
         componentRight={form}
       />
@@ -109,6 +111,7 @@ export const demoQuery = graphql`
       id
       slug
       title
+      header
       description
       formButtonText
       requesterType

--- a/src/layouts/featurePage.tsx
+++ b/src/layouts/featurePage.tsx
@@ -14,13 +14,20 @@ const FeaturePage = ({
     allContentfulFeaturePage2021: UnknownObject;
   };
 }) => {
-  const { title, description, graphic, motivationText, entries } = data.contentfulFeaturePage2021;
+  const {
+    title,
+    header,
+    description,
+    graphic,
+    motivationText,
+    entries,
+  } = data.contentfulFeaturePage2021;
   return (
     <div>
-      <Title title={dynamicI18n(title)} description={dynamicI18n(description)} />
+      <Title title={dynamicI18n(title || header)} description={dynamicI18n(description)} />
       <TitleWithGraphic
-        id={title}
-        title={title}
+        id={header}
+        title={header}
         description={description}
         graphic={graphic}
         motivationText={motivationText}
@@ -42,6 +49,7 @@ export const featurePageQuery = graphql`
       id
       slug
       title
+      header
       description
       motivationText
       graphic {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const isTopPageComponent = (entry: MainPageEntryProps) =>
 const IndexPage = (props: Props) => {
   const { data, prefix } = props;
   const [content] = data.page.edges;
-  const { entries }: { entries: MainPageEntryProps[] } = content.node;
+  const { entries, title }: { entries: MainPageEntryProps[]; title: string } = content.node;
 
   const topBanner = entries.find(isTopBanner);
   const { mainHeader } = topBanner || {};
@@ -25,7 +25,7 @@ const IndexPage = (props: Props) => {
     <main className="main-wrapper-1">
       {!!mainHeader && (
         <Helmet>
-          <title>{`Ledgy: ${dynamicI18n(mainHeader)}`}</title>
+          <title>{`Ledgy: ${dynamicI18n(title || mainHeader)}`}</title>
         </Helmet>
       )}
       <div className="main-wrapper-2">
@@ -194,6 +194,7 @@ export const indexPageQuery = graphql`
     page: allContentfulFrontPage2021 {
       edges {
         node {
+          title
           entries {
             ... on ContentfulTopBanner {
               id


### PR DESCRIPTION
### What has changed:
- new `title` field (optional) for pages for SEO: front page, feature page, demo page and customer page
- rename previous `title` as `header` for users to read

#### Front Page
![Screenshot from 2021-03-22 18-40-37](https://user-images.githubusercontent.com/39551291/112034850-3b5bbb00-8b3f-11eb-8765-6ce747cea7f3.png)
#### Feature Page
![Screenshot from 2021-03-22 18-40-50](https://user-images.githubusercontent.com/39551291/112034957-5c241080-8b3f-11eb-9a26-5084a791802e.png)
#### Demo Page
![Screenshot from 2021-03-22 18-41-07](https://user-images.githubusercontent.com/39551291/112034968-60502e00-8b3f-11eb-87d3-1d52c0e01ae8.png)
#### Customer Story Page
![Screenshot from 2021-03-22 19-03-16](https://user-images.githubusercontent.com/39551291/112036791-592a1f80-8b41-11eb-8174-58e8110cf64b.png)
