### PR TITLE
remove pages with /en/ prefix

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const { redirects } = require('./src/redirects.js');
 
-const { languages, defaultLanguage } = require('./src/i18n-config.js');
+const { languages, langPrefix } = require('./src/i18n-config.js');
 
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
@@ -22,7 +22,7 @@ exports.onCreatePage = async ({ page, actions }) => {
       languages.forEach((language) => {
         const newPage = Object.assign({}, page, {
           originalPath: page.path,
-          path: language === defaultLanguage ? page.path : `/${language}${page.path}`,
+          path: `${langPrefix(language)}${page.path}`,
           context: { lang: language },
         });
         createPage(newPage);
@@ -142,8 +142,9 @@ const resolvePagePromise = (query, createPageWithData) =>
 exports.createPages = ({ graphql, actions }) => {
   const { createPage, createRedirect } = actions;
   const createLocalizedPages = (pagePath, component, context) => {
-    createPage({ path: pagePath, component, context });
-    languages.forEach((lang) => createPage({ path: `/${lang}${pagePath}`, component, context }));
+    languages.forEach((language) =>
+      createPage({ path: `${langPrefix(language)}${pagePath}`, component, context })
+    );
   };
 
   redirects.forEach(([from, toPath]) => {

--- a/src/components/HelmetIndexLayout.tsx
+++ b/src/components/HelmetIndexLayout.tsx
@@ -1,6 +1,7 @@
 import { Helmet } from 'react-helmet';
 import React from 'react';
 import { name, getLdJson, dynamicI18n } from '../helpers';
+import { langPrefix } from '../i18n-config';
 
 export const HelmetIndexLayout = ({
   lang,
@@ -32,6 +33,7 @@ export const HelmetIndexLayout = ({
     <link rel="alternate" href={`${siteUrl}${pathname}`} hrefLang="en" />
     <link rel="alternate" href={`${siteUrl}/de${pathname}`} hrefLang="de" />
     <link rel="alternate" href={`${siteUrl}/fr${pathname}`} hrefLang="fr" />
+    <link rel="canonical" href={`${siteUrl}${langPrefix(lang)}${pathname}`} />
     <script src="https://www.googleoptimize.com/optimize.js?id=OPT-PHR22QK" />
     <script>
       {`

--- a/src/components/lib/urlHelpers.ts
+++ b/src/components/lib/urlHelpers.ts
@@ -1,6 +1,6 @@
 export const isExternalUrl = (url: string) => url.startsWith('http') || url.startsWith('www');
 
-export const formatUrl = (prefix: string, url: string) => `${prefix}/${url}`;
+export const formatUrl = (prefix: string, url: string) => `${prefix}/${url}/`;
 
 export const checkAndFormatUrl = (prefix: string, url: string) =>
   isExternalUrl(url) ? url : formatUrl(prefix, url);


### PR DESCRIPTION
* Remove broken duplicate pages like https://ledgy.com/en/calculator/ (should be https://ledgy.com/calculator/) that harm our SEO
* Add `rel="canonical"` to all pages ([background](https://www.portent.com/blog/seo/implement-hreflang-canonical-tags-correctly.htm))
* Add missing trailing slash to internal URLs (eg. `/finance-legal-accounting` → `/finance-legal-accounting/`)