### PR TITLE
Lg 3935/show entries on page component

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,6 +71,10 @@ exports.createSchemaCustomization = ({ actions }) => {
   type ContentfulCustomerStory implements Node {
     title: String
   }
+  type ContentfulPage implements Node {
+    title: String
+    entries: [EntryProps] @link(by: "id", from: "entries___NODE")
+  }
 `;
   createTypes(typeDefinitions);
 };

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -20,6 +20,7 @@ declare type ContentfulPageProps = Id & {
   slug: string;
   language: Language;
   cover?: ImageProps;
+  entries?: EntryProps[];
 };
 
 declare type AllContentfulCustomerStoryProps = Id & {

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -112,6 +112,7 @@ export const contentfulPageQuery = graphql`
         ...SelectableCardsWithScreenshotsFragment
         ...CallToAction2021Fragment
         ...ChecklistWithScreenshotFragment
+        ...LongTextBuildingBlockFragment
       }
     }
     site {

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -70,9 +70,9 @@ const ContentfulPage = ({
         <LongText content={content} prefix={prefix} />
         <PublishDate date={date} />
         {author && <Author prefix={prefix} name={author} />}
+        {!!entries &&
+          entries.map((entry) => <ComponentPicker key={entry.id} entry={entry} prefix={prefix} />)}
       </div>
-      {!!entries &&
-        entries.map((entry) => <ComponentPicker key={entry.id} entry={entry} prefix={prefix} />)}
     </div>
   );
 };
@@ -112,7 +112,7 @@ export const contentfulPageQuery = graphql`
         ...SelectableCardsWithScreenshotsFragment
         ...CallToAction2021Fragment
         ...ChecklistWithScreenshotFragment
-        ...LongTextBuildingBlockFragment
+        ...LongTextFragment
       }
     }
     site {

--- a/src/layouts/page.tsx
+++ b/src/layouts/page.tsx
@@ -3,7 +3,14 @@ import { graphql } from 'gatsby';
 import { GatsbyImageFluidProps } from 'gatsby-image';
 
 import { dynamicI18n } from '../helpers';
-import { PublishDate, Author, LongText, PageHeader, CalculatorHeader } from '../components';
+import {
+  PublishDate,
+  Author,
+  LongText,
+  PageHeader,
+  CalculatorHeader,
+  ComponentPicker,
+} from '../components';
 import { Title } from '../layouts/utils';
 
 const CALCULATOR_SLUG = 'calculator';
@@ -21,7 +28,17 @@ const ContentfulPage = ({
 }) => {
   if (!data) return null;
 
-  const { slug, title, description, language, content, author, date, cover } = data.contentfulPage;
+  const {
+    slug,
+    title,
+    description,
+    language,
+    content,
+    author,
+    date,
+    cover,
+    entries,
+  } = data.contentfulPage;
   const { siteUrl } = data.site.siteMetadata;
   const showCalculatorHeader = slug === CALCULATOR_SLUG;
   const { childImageSharp } = cover?.localFile || {};
@@ -54,6 +71,8 @@ const ContentfulPage = ({
         <PublishDate date={date} />
         {author && <Author prefix={prefix} name={author} />}
       </div>
+      {!!entries &&
+        entries.map((entry) => <ComponentPicker key={entry.id} entry={entry} prefix={prefix} />)}
     </div>
   );
 };
@@ -83,6 +102,16 @@ export const contentfulPageQuery = graphql`
             }
           }
         }
+      }
+      entries {
+        ...FeatureGridFramgent
+        ...TestimonialCardsFragment
+        ...ContentWithChecklistFragment
+        ...TitleWithGraphicFragment
+        ...LogoBannerFragment
+        ...SelectableCardsWithScreenshotsFragment
+        ...CallToAction2021Fragment
+        ...ChecklistWithScreenshotFragment
       }
     }
     site {


### PR DESCRIPTION
- https://ledgy.atlassian.net/browse/LG-3935?atlOrigin=eyJpIjoiNGZiNjE2ZTFhMGZlNDBiZWFlNzAxZDdlNzhhZTAzNjYiLCJwIjoiaiJ9
- Added an optional `Entries` field to `Page` Contentful model, where all standard components (such as CTA, Screenshot with checklists) can be added to allow more flexibility in pages, an example can be seen here:  [Test Example](https://app.contentful.com/spaces/ojxc8xtj0owo/entries/3LqRrTTmVx2UiwliMpsf7y)
- How the test example looks on landing page:
![Screenshot from 2021-04-23 16-35-06](https://user-images.githubusercontent.com/39551291/115887109-e79c0480-a451-11eb-8da9-5c99cf02c518.png)
