### PR TITLE
Reduce markdown text size to match other font sizes

### DIFF
--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -237,6 +237,8 @@ input[type=number]::-webkit-outer-spin-button {
 
 // Customer stories
 .company-summary {
+  font-size: $ledgy-font-size;
+  line-height: 1.5rem;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
   top: calc(#{$navbar-min-height} + 15px);
   z-index: $zindex-company-summary;
@@ -248,8 +250,6 @@ input[type=number]::-webkit-outer-spin-button {
 
 .company-summary-quote {
   font-style: italic;
-  font-size: 1.2rem;
-  line-height: 1.5rem;
 }
 
 // Newsletter

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -238,7 +238,7 @@ input[type=number]::-webkit-outer-spin-button {
 // Customer stories
 .company-summary {
   font-size: $ledgy-font-size;
-  line-height: 1.5rem;
+  line-height: 1.9rem;
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.25);
   top: calc(#{$navbar-min-height} + 15px);
   z-index: $zindex-company-summary;

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1,4 +1,4 @@
-$markdown-font-size: 1.2rem;
+$markdown-font-size: $ledgy-font-size * 1.12;
 $markdown-spacer: $markdown-font-size;
 $markdown-container-width: 720px;
 $markdown-container-wide-width: 1200px;

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -1,4 +1,4 @@
-$markdown-font-size: $ledgy-font-size * 1.12;
+$markdown-font-size: $ledgy-font-size;
 $markdown-spacer: $markdown-font-size;
 $markdown-container-width: 720px;
 $markdown-container-wide-width: 1200px;
@@ -34,7 +34,7 @@ $markdown-container-wide-width: 1200px;
   }
   blockquote {
     margin: map-get($spacers, 6) map-get($spacers, 3);
-    font-size: 1.2em;
+    font-size: $markdown-font-size;
     font-style: italic;
     font-weight: 200;
   }
@@ -48,7 +48,7 @@ $markdown-container-wide-width: 1200px;
     font-weight: 400;
   }
   .lead {
-    font-size: 1.4rem;
+    font-size: $markdown-font-size * 1.12;
     margin-bottom: map-get($spacers, 7);
   }
   .katex {

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -27,6 +27,7 @@ $markdown-container-wide-width: 1200px;
   h6 {
     margin-top: 2 * $markdown-spacer;
     margin-bottom: 0.5 * $markdown-spacer;
+    line-height: 2rem;
   }
   li {
     margin-bottom: map-get($spacers, 1);
@@ -48,8 +49,8 @@ $markdown-container-wide-width: 1200px;
     font-weight: 400;
   }
   .lead {
-    font-size: $markdown-font-size * 1.12;
-    margin-bottom: map-get($spacers, 7);
+    font-size: $markdown-font-size;
+    margin-bottom: map-get($spacers, 10);
   }
   .katex {
     font-size: 1em;


### PR DESCRIPTION
- make markdown text smaller, = $ledgy-font-size(17px)

#### how to test
- click deploy/netlify details in the following checks section on this page to see the preview
- check blogs, updates, customer stories and see whether the text size makes sense