### PR TITLE
LG-5043/add custom Buttons to individual marketplace page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -284,7 +284,7 @@ exports.createPages = ({ graphql, actions }) => {
   const jobPageComponent = path.resolve(`${basePath}/job.tsx`);
   const createJobPages = resolvePagePromise(graphql(jobQuery), (data) =>
     data.allGreenhouseJob.nodes.forEach(({ id, gh_Id }) => {
-      const pagePath = `/jobs/${gh_Id}/`;
+      const pagePath = `/careers/${gh_Id}/`;
       const context = { id };
       createLocalizedPages(pagePath, jobPageComponent, context);
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -285,15 +285,15 @@ exports.createPages = ({ graphql, actions }) => {
   const createJobPages = resolvePagePromise(graphql(jobQuery), (data) =>
     data.allGreenhouseJob.nodes.forEach(({ id, gh_Id }) => {
       const pagePath = `/careers/${gh_Id}/`;
-      const fromPage = `/jobs/${gh_Id}/`;
       const context = { id };
       createLocalizedPages(pagePath, jobPageComponent, context);
-      createRedirect({ fromPage, toPath: pagePath, redirectInBrowser: true });
+      const fromPath = `/jobs/${gh_Id}/`;
+      createRedirect({ fromPath: fromPath, toPath: pagePath, redirectInBrowser: true });
       languages.forEach((lang) =>
         createRedirect({
-          fromPath: `/${lang}${fromPage}`,
+          fromPath: `/${lang}${fromPath}`,
           toPath: `/${lang}${pagePath}`,
-          redirectInBrowser,
+          redirectInBrowser: true,
         })
       );
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -285,8 +285,17 @@ exports.createPages = ({ graphql, actions }) => {
   const createJobPages = resolvePagePromise(graphql(jobQuery), (data) =>
     data.allGreenhouseJob.nodes.forEach(({ id, gh_Id }) => {
       const pagePath = `/careers/${gh_Id}/`;
+      const fromPage = `/jobs/${gh_Id}/`;
       const context = { id };
       createLocalizedPages(pagePath, jobPageComponent, context);
+      createRedirect({ fromPage, toPath: pagePath, redirectInBrowser: true });
+      languages.forEach((lang) =>
+        createRedirect({
+          fromPath: `/${lang}${fromPage}`,
+          toPath: `/${lang}${pagePath}`,
+          redirectInBrowser,
+        })
+      );
     })
   );
 

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -57,6 +57,7 @@ declare type MarketplaceProps = MarketplaceBaseProps & {
   content: Mdx;
   motivationText: string;
   pictures: ImageProps[];
+  buttons: ButtonProps[];
 };
 
 declare type FeatureGridSectionProps = { icon: IconType; title: string; description: string };

--- a/src/components/ContactUs/Emails.tsx
+++ b/src/components/ContactUs/Emails.tsx
@@ -28,7 +28,7 @@ export const Emails = () => (
     </div>
     <div className="mb-4">
       <h6>
-        <Trans>Career</Trans>
+        <Trans>Careers</Trans>
       </h6>
       <a href="mailto:work@ledgy.com">work@ledgy.com</a>
     </div>

--- a/src/components/CustomButton.tsx
+++ b/src/components/CustomButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { DynamicTrans, Button } from './utils';
+
+export const CustomButton = ({
+  url,
+  text,
+  isPrimary,
+  isTopBanner,
+}: {
+  url: string;
+  text: string;
+  isPrimary: boolean;
+  isTopBanner: boolean;
+}) => (
+  <Button
+    href={url}
+    className="btn-xl mr-2 my-1 align-self-center"
+    inverted={(isTopBanner && !isPrimary) || (!isTopBanner && isPrimary)}
+    outline={(isTopBanner && !isPrimary) || (!isTopBanner && !isPrimary)}
+  >
+    <DynamicTrans>{text}</DynamicTrans>
+  </Button>
+);

--- a/src/components/JobBoard.tsx
+++ b/src/components/JobBoard.tsx
@@ -25,7 +25,7 @@ const getJobs = () =>
   `);
 
 const Job = ({ title, gh_Id, prefix }: GreenhouseJobProps & Prefix) => {
-  const page = `/jobs/${gh_Id}`;
+  const page = `/careers/${gh_Id}`;
   const url = `${formatUrl(prefix, page)}${getSearchString()}`;
 
   return (

--- a/src/components/TitleWithGraphic.tsx
+++ b/src/components/TitleWithGraphic.tsx
@@ -1,30 +1,10 @@
 import React from 'react';
 
 import { dynamicI18n } from '../helpers';
-import { DynamicTrans, Section, Image, Button } from './utils';
+import { DynamicTrans, Section, Image } from './utils';
 import { formatUrl, getUnderlineHtml } from './lib';
 import { RichTextHeader } from './RichTextHeader';
-
-const CustomButton = ({
-  url,
-  text,
-  isPrimary,
-  isTopBanner,
-}: {
-  url: string;
-  text: string;
-  isPrimary: boolean;
-  isTopBanner: boolean;
-}) => (
-  <Button
-    href={url}
-    className="btn-xl mr-2 my-1 align-self-center"
-    inverted={(isTopBanner && !isPrimary) || (!isTopBanner && isPrimary)}
-    outline={(isTopBanner && !isPrimary) || (!isTopBanner && !isPrimary)}
-  >
-    <DynamicTrans>{text}</DynamicTrans>
-  </Button>
-);
+import { CustomButton } from './CustomButton';
 
 export const TitleWithGraphic = ({
   title,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,3 +32,4 @@ export * from './TitleWithGraphic';
 export * from './Testimonial';
 export * from './TopBannerLayout';
 export * from './utils';
+export * from './CustomButton';

--- a/src/components/lib/textHelpers.ts
+++ b/src/components/lib/textHelpers.ts
@@ -40,7 +40,7 @@ export type FooterLink = [string, string];
 const companyLinks: FooterLink[] = [
   ['Team', 'team'],
   ['Sustainability', 'sustainability'],
-  ['Career', 'jobs'],
+  ['Careers', 'careers'],
   ['Contact', 'contact'],
 ];
 
@@ -271,7 +271,7 @@ const companyTypes: NavbarMenuColumn = {
       icon: 'team',
     },
     {
-      link: 'jobs',
+      link: 'careers',
       title: 'Careers',
       description: 'Join us on our mission',
       icon: 'careers',

--- a/src/components/lib/textHelpers.ts
+++ b/src/components/lib/textHelpers.ts
@@ -38,7 +38,7 @@ export const getUnderlineHtml = (text: string): string =>
 export type FooterLink = [string, string];
 
 const companyLinks: FooterLink[] = [
-  ['About us', 'about-us'],
+  ['Team', 'team'],
   ['Sustainability', 'sustainability'],
   ['Career', 'jobs'],
   ['Contact', 'contact'],
@@ -259,13 +259,13 @@ const pricingTypes: NavbarMenuColumn = {
 const companyTypes: NavbarMenuColumn = {
   items: [
     {
-      link: 'our-story',
+      link: 'about-us',
       title: 'About Us',
       description: 'Our values and our why',
       icon: 'aboutUs',
     },
     {
-      link: 'about-us',
+      link: 'team',
       title: 'Team',
       description: 'Get to know the Ledgistas',
       icon: 'team',

--- a/src/components/nav/MobileNavbar.tsx
+++ b/src/components/nav/MobileNavbar.tsx
@@ -6,8 +6,8 @@ import { NAVBAR_TITLES, NAVBAR_LINKS, formatUrl, isExternalUrl, NavbarMenuColumn
 import { targetBlank } from '../../helpers';
 import { DynamicTrans } from '../utils';
 
-const { solutionsTitle, resourcesTitle, pricingTitle } = NAVBAR_TITLES;
-const { solutions, resources, pricing } = NAVBAR_LINKS;
+const { solutionsTitle, resourcesTitle, pricingTitle, companyTitle } = NAVBAR_TITLES;
+const { solutions, resources, pricing, company } = NAVBAR_LINKS;
 
 const MobileNavbarGroup = ({
   title,
@@ -63,6 +63,7 @@ const titlesAndColumns: [string, NavbarMenuColumn[]][] = [
   [solutionsTitle, solutions],
   [resourcesTitle, resources],
   [pricingTitle, pricing],
+  [companyTitle, company],
 ];
 
 export const MobileNavbar = ({

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -109,7 +109,7 @@ console.log(`
 ==========================
 
 Looking for a job? 🤓
-https://ledgy.com/jobs
+https://ledgy.com/careers
 
 ==========================
 `);

--- a/src/layouts/marketplace.tsx
+++ b/src/layouts/marketplace.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { graphql } from 'gatsby';
-import { CustomFade, Image, LongText } from '../components';
+import { CustomButton, CustomFade, DynamicTrans, Image, LongText } from '../components';
 import { Title } from './utils';
 import { MarketplaceSummary } from '../components/marketplace/MarketplaceSummary';
 import { MarketplacePictures } from './MarketplacePictures';
+import { formatUrl } from '../components/lib';
 
 const Marketplace = ({
   data,
@@ -13,8 +14,17 @@ const Marketplace = ({
     contentfulMarketplace: MarketplaceProps;
   };
 }) => {
-  const { company, logo, header, description, summary, content, motivationText, pictures } =
-    data.contentfulMarketplace;
+  const {
+    company,
+    logo,
+    header,
+    buttons,
+    description,
+    summary,
+    content,
+    motivationText,
+    pictures,
+  } = data.contentfulMarketplace;
 
   return (
     <div>
@@ -23,12 +33,27 @@ const Marketplace = ({
         <div className="pt-6 bg-lightest">
           <div className="container">
             <div className="row">
-              <div className="col-12 col-lg-8 p-4 mb-6">
-                <CustomFade translate="-100px, 0" className="px-3">
-                  <p className="text-lg">{motivationText.toUpperCase()}</p>
+              <div className="col-12 col-lg-8 p-4 mb-6 px-3">
+                <CustomFade translate="-100px, 0">
+                  <p className="text-lg">
+                    <DynamicTrans>{motivationText.toUpperCase()}</DynamicTrans>
+                  </p>
                   <h1>{company}</h1>
-                  <p className="text-lg">{description}</p>
+                  <p className="text-lg">
+                    <DynamicTrans>{description}</DynamicTrans>
+                  </p>
                 </CustomFade>
+                <div className="d-flex align-items-center flex-wrap">
+                  {buttons.map(({ id, text, url }, index) => (
+                    <CustomButton
+                      key={id}
+                      text={text}
+                      url={formatUrl(prefix, url)}
+                      isPrimary={index === 0}
+                      isTopBanner={true}
+                    />
+                  ))}
+                </div>
               </div>
               <div className="col-12 col-lg-4">
                 <div className="bg-secondary d-flex flex-column justify-content-center align-items-center h-100 p-5 marketplace-logo">
@@ -65,6 +90,9 @@ export const marketplaceQuery = graphql`
       header
       company
       description
+      buttons {
+        ...ButtonFragment
+      }
       logo {
         localFile {
           childImageSharp {

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -5,4 +5,5 @@ exports.redirects = [
   ['/esop', esopTemplates],
   ['/psop', esopTemplates],
   ['/equity-plans', esopTemplates],
+  ['/jobs', '/careers'],
 ];


### PR DESCRIPTION
Tickets:
- https://ledgy.atlassian.net/browse/LG-5043
- https://ledgy.atlassian.net/browse/LG-5043

1. added buttons for individual marketplace page (e.g. `.../integrations/bamboohr/`)
![Screenshot from 2021-11-12 14-43-50](https://user-images.githubusercontent.com/39551291/141477107-317f5097-f6ed-4001-895b-f25608898584.png)

2. Changed a few URL snugs
 - `about-us` now points to ledgy's story
 - `team` now points to ledgitas page
 - `jobs` replaced by `careers`, previous `.../jobs/` will be redirect to `.../careers/`, and all job ads `.../jobs/XXXXXX` will be redirected to `.../careers/XXXXXXX`
![Screenshot from 2021-11-12 14-46-42](https://user-images.githubusercontent.com/39551291/141477121-a09e776e-3008-4732-b0b0-bc206ecdb7a5.png)
![Screenshot from 2021-11-12 14-46-57](https://user-images.githubusercontent.com/39551291/141477128-877f18a9-9944-4f59-b807-19394360cb40.png)

