### PR TITLE
lg-5283 | Page speed improvements

### DIFF
--- a/src/components/ClickCease.tsx
+++ b/src/components/ClickCease.tsx
@@ -11,6 +11,7 @@ export const ClickCease = () => (
          var target = 'https://www.clickcease.com/monitor/stat.js';
          script.src = target;var elem = document.head;
          elem.appendChild(script);
+         script.defer = true;
        `}
       </script>
     </Helmet>

--- a/src/components/HelmetIndexLayout.tsx
+++ b/src/components/HelmetIndexLayout.tsx
@@ -21,7 +21,9 @@ export const HelmetIndexLayout = ({
       <html lang={lang} />
       <meta name="keywords" content={dynamicI18n(keywords.join(', '))} />
       <meta name="author" content="Ledgy" />
-      <script type="application/ld+json">{getLdJson(siteUrl)}</script>
+      <script defer type="application/ld+json">
+        {getLdJson(siteUrl)}
+      </script>
 
       {/* Facebook social card */}
       <meta property="og:site_name" content={name} />
@@ -39,7 +41,7 @@ export const HelmetIndexLayout = ({
       <link rel="alternate" href={`${siteUrl}/de${pathname}`} hrefLang="de" />
       <link rel="alternate" href={`${siteUrl}/fr${pathname}`} hrefLang="fr" />
       <link rel="canonical" href={`${siteUrl}${langPrefix(lang)}${pathname}`} />
-      <script src="https://www.googleoptimize.com/optimize.js?id=OPT-PHR22QK" />
+      <script defer src="https://www.googleoptimize.com/optimize.js?id=OPT-PHR22QK" />
 
       {/* Disable AOS for Google */}
       <noscript>

--- a/src/components/TopBanner.tsx
+++ b/src/components/TopBanner.tsx
@@ -34,6 +34,9 @@ export const TopBanner = ({
   secondButtonUrl,
   prefix,
 }: TopBannerProps & Prefix) => {
+  //disable lazy loading to decrease full contentfull paint
+  if (image.localFile) image.localFile.childImageSharp.loading = 'eager';
+
   const buttonClassName = 'my-sm-0 my-2 btn-xl d-inline mr-2';
 
   const buttonOne = firstButtonUrl.includes(demoPage) ? (

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -15,7 +15,7 @@ import { MobileNavbar } from './MobileNavbar';
 const Logo = (props: LayoutProps) => {
   return (
     <Link to={`${props.prefix}/#start`}>
-      <img className="navbar-logo" src={logo} alt={name} width="130" height="36" />
+      <img className="navbar-logo" src={logo} alt={name} width="141" height="42" />
     </Link>
   );
 };

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -15,7 +15,7 @@ import { MobileNavbar } from './MobileNavbar';
 const Logo = (props: LayoutProps) => {
   return (
     <Link to={`${props.prefix}/#start`}>
-      <img className="navbar-logo" src={logo} alt={name} />
+      <img className="navbar-logo" src={logo} alt={name} width="130" height="36" />
     </Link>
   );
 };

--- a/src/components/utils/CustomFade.tsx
+++ b/src/components/utils/CustomFade.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import Reveal from 'react-awesome-reveal';
 import { keyframes } from '@emotion/react';
 import type { RevealProps } from 'react-awesome-reveal/dist/Reveal';
@@ -8,6 +8,7 @@ export const CustomFade = ({
   translate,
   ...props
 }: { children: ReactNode; translate?: string } & RevealProps) => {
+  const isBrowser = () => typeof window !== 'undefined';
   const animation = keyframes`
   from {
     opacity: 0;
@@ -18,10 +19,27 @@ export const CustomFade = ({
     transform: translate(0, 0);
   }
 `;
-
-  return (
+  const AnimatedJSXElement = (
     <Reveal keyframes={animation} {...props}>
       {children}
     </Reveal>
   );
+  if (isBrowser()) {
+    const [width, setWidth] = useState<number>(window.innerWidth);
+
+    const handleWindowSizeChange = () => {
+      setWidth(window.innerWidth);
+    };
+
+    useEffect(() => {
+      window.addEventListener('resize', handleWindowSizeChange);
+      return () => {
+        window.removeEventListener('resize', handleWindowSizeChange);
+      };
+    }, []);
+    const isMobile = width <= 768;
+    return isMobile ? <>{children}</> : AnimatedJSXElement;
+  }
+
+  return AnimatedJSXElement;
 };

--- a/src/components/utils/Icon.tsx
+++ b/src/components/utils/Icon.tsx
@@ -13,5 +13,7 @@ export const Icon = ({
 }) => {
   const src = require(`../../img/svg/icons/${icon}.svg`).default;
 
-  return src ? <img src={src} height={height} width={width} className={className} /> : null;
+  return src ? (
+    <img src={src} height={height} width={width} className={className} alt={`${icon} icon`} />
+  ) : null;
 };

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -1,15 +1,17 @@
 @font-face {
   font-family: 'Museo Sans Rounded';
   src: url('../../static/fonts/museo-sans-rounded-500.woff2') format('woff2'),
-       url('../../static/fonts/museo-sans-rounded-500.woff') format('woff');
+    url('../../static/fonts/museo-sans-rounded-500.woff') format('woff');
   font-weight: normal;
   font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
   font-family: 'Museo Sans Rounded';
   src: url('../../static/fonts/museo-sans-rounded-700.woff2') format('woff2'),
-       url('../../static/fonts/museo-sans-rounded-700.woff') format('woff');
+    url('../../static/fonts/museo-sans-rounded-700.woff') format('woff');
   font-weight: bold;
   font-style: normal;
+  font-display: swap;
 }


### PR DESCRIPTION
Display text before loading fonts: `font-display:swap`
disable transitions on mobile: `isMobile`
Give default size to logo image :`width 80`
Lazy-load scripts waiting for usage :`defer`


### To test:
Just download the website and check if it still works
![image](https://user-images.githubusercontent.com/86734894/145415647-6c788033-00bb-4135-a492-d990d8eb05c3.png)

Performance issues can be checked at this link https://pagespeed.web.dev/report?url=https%3A%2F%2Fledgy.com%2F
