### PR TITLE
Generate custom landingpages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -60,7 +60,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   type ContentfulTitleWithGraphic implements Node {
     buttons: [ContentfulButton] @link(by: "id", from: "buttons___NODE")
   }
-  union EntryProps = ContentfulTopBanner | ContentfulLogoBanner | ContentfulSelectableCardsWithScreenshots | ContentfulFeatureGrid | ContentfulTestimonialCards | ContentfulTitleWithGraphic | ContentfulContentWithChecklist | ContentfulCallToAction2021 | ContentfulChecklistWithScreenshot | ContentfulLongText | ContentfulStaticBlock
+  union EntryProps = ContentfulTopBanner | ContentfulLogoBanner | ContentfulSelectableCardsWithScreenshots | ContentfulFeatureGrid | ContentfulTestimonialCards | ContentfulTestimonials | ContentfulTitleWithGraphic | ContentfulContentWithChecklist | ContentfulCallToAction2021 | ContentfulChecklistWithScreenshot | ContentfulLongText | ContentfulStaticBlock
   type ContentfulDemoPage2021 implements Node {
     title: String
     requesterType: String

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -174,6 +174,19 @@ const featurePageQuery = `
 }
 `;
 
+const customLandingPageQuery = `
+{
+  allContentfulCustomLandingPageWithBanner(limit: 1000) {
+    edges {
+      node {
+        id
+        slug
+      }
+    }
+  }
+}
+`;
+
 const demoQuery = `
 {
   allContentfulDemoPage2021(limit: 1000) {
@@ -270,6 +283,15 @@ exports.createPages = ({ graphql, actions }) => {
       createLocalizedPages(pagePath, featurePageComponent, context);
     })
   );
+  const customLandingPageComponent = path.resolve(`${basePath}/customLandingPage.tsx`);
+  const createCustomLandingPages = resolvePagePromise(graphql(customLandingPageQuery), (data) =>
+    data.allContentfulCustomLandingPageWithBanner.edges.forEach(({ node }) => {
+      const { id, slug } = node;
+      const pagePath = `/${slug}/`;
+      const context = { id };
+      createLocalizedPages(pagePath, customLandingPageComponent, context);
+    })
+  );
 
   const demoPageComponent = path.resolve(`${basePath}/demo.tsx`);
   const createDemoPages = resolvePagePromise(graphql(demoQuery), (data) =>
@@ -304,6 +326,7 @@ exports.createPages = ({ graphql, actions }) => {
     createCustomerStories,
     createMarketplaces,
     createFeaturePages,
+    createCustomLandingPages,
     createDemoPages,
     createJobPages,
   ];

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -118,6 +118,13 @@ declare type FeaturePageProps = BaseFeatureProps & {
   headerWithMedia?: RichText;
 };
 
+declare type CustomLandingPageProps = {
+  title: string;
+  description: string;
+  slug: string;
+  entries: EntryProps[];
+};
+
 declare type TitleWithGraphicProps = BaseFeatureProps & {
   __typename: 'ContentfulTitleWithGraphic';
   headerWithMedia?: RichText;

--- a/src/@types/contentful.d.ts
+++ b/src/@types/contentful.d.ts
@@ -10,7 +10,8 @@ declare type EntryProps =
   | CallToActionProps
   | ChecklistWithScreenshotProps
   | LongTextComponentProps
-  | StaticBlockProps;
+  | StaticBlockProps
+  | TestimonialsProps;
 
 declare type ContentfulPageProps = Id & {
   title: string;
@@ -76,11 +77,23 @@ declare type TestimonialCardProps = {
   linkUrl?: string;
 };
 
+declare type TestimonialProps = {
+  name: string;
+  description: Mdx;
+  url: string;
+  image: ImageProps;
+  small: boolean;
+};
+
 declare type TestimonialCardsProps = Id & {
   __typename: 'ContentfulTestimonialCards';
   cards: TestimonialCardProps[];
 };
 
+declare type TestimonialsProps = Id & {
+  __typename: 'ContentfulTestimonials';
+  testimonial: TestimonialProps[];
+};
 declare type ButtonProps = Id & {
   __typename: 'ContentfulButton';
   text: string;

--- a/src/components/ComponentPicker.tsx
+++ b/src/components/ComponentPicker.tsx
@@ -11,6 +11,7 @@ import { TopBanner } from './TopBanner';
 import { ChecklistWithScreenshot } from './ChecklistWithScreenshot';
 import { LongTextComponent } from './LongTextComponent';
 import { StaticBlockPicker } from './StaticBlockPicker';
+import { Testimonials } from './Testimonials';
 
 export const ComponentPicker = ({
   entry,
@@ -52,6 +53,9 @@ export const ComponentPicker = ({
 
     case 'ContentfulStaticBlock':
       return <StaticBlockPicker {...entry} prefix={prefix} />;
+
+    case 'ContentfulTestimonials':
+      return <Testimonials {...entry} />;
 
     default:
       throw new Error('content __typename not recognized');

--- a/src/components/Testimonial.tsx
+++ b/src/components/Testimonial.tsx
@@ -11,9 +11,9 @@ export const Testimonial = ({
   rounded,
   minHeight = 80,
 }: {
-  img: GatsbyImageProps;
+  img: GatsbyImageProps | undefined;
   name: string;
-  description: ReactNode;
+  description: ReactNode | string;
   col: number;
   url?: string;
   rounded?: boolean;
@@ -27,12 +27,12 @@ export const Testimonial = ({
       style={minHeight ? { minHeight } : {}}
     >
       <a {...targetBlank} href={url}>
-        <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />
+        {img && <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />}
       </a>
     </div>
     <div className="d-flex flex-column justify-content-between mt-4 h-100">
       <div className="testimonial-description">{description}</div>
-      <small className="text-muted mt-4" style={{ minHeight: '80px' }}>
+      <small className="text-muted mt-0" style={{ minHeight: '80px' }}>
         {name}
       </small>
     </div>

--- a/src/components/Testimonial.tsx
+++ b/src/components/Testimonial.tsx
@@ -26,9 +26,11 @@ export const Testimonial = ({
       className="d-flex align-items-center justify-content-center mt-4"
       style={minHeight ? { minHeight } : {}}
     >
-      <a {...targetBlank} href={url}>
-        {img && <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />}
-      </a>
+      {img && (
+        <a {...targetBlank} href={url}>
+          <Img {...img} alt={name} className={rounded ? 'avatar' : ''} />
+        </a>
+      )}
     </div>
     <div className="d-flex flex-column justify-content-between mt-4 h-100">
       <div className="testimonial-description">{description}</div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Testimonial } from '.';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+
+export const Testimonials = (data: TestimonialsProps) => {
+  const testimonials = data.testimonial;
+
+  return (
+    <div className="p-15">
+      <div className="row text-center justify-content-center my-4 mx-8">
+        {testimonials.map(({ name, description, url, image, small }, ind) => (
+          <Testimonial
+            col={small ? 3 : 5}
+            key={ind}
+            name={name}
+            url={url}
+            img={image.localFile?.childImageSharp}
+            description={<MDXRenderer>{description.childMdx.body}</MDXRenderer>}
+            rounded={small}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/forms/DemoForm.tsx
+++ b/src/components/forms/DemoForm.tsx
@@ -12,9 +12,11 @@ const REQUESTER_TYPES = [COMPANY, INVESTOR];
 export const DemoForm = ({
   buttonText,
   contentfulRequesterType,
+  slug,
 }: {
   buttonText: string;
   contentfulRequesterType: RequesterType | void;
+  slug: string;
 }) => {
   const [requesterType, setRequesterType] = useState(contentfulRequesterType || COMPANY);
   const [email, setEmail] = useState('');
@@ -28,7 +30,7 @@ export const DemoForm = ({
     <div className="card-border-style bg-white mx-md-7 mx-xl-6">
       <form
         method="post"
-        onSubmit={(event) => handleDemoSubmit({ values, event, setFormStatus })}
+        onSubmit={(event) => handleDemoSubmit({ values, event, slug, setFormStatus })}
         noValidate
         className="w-100 p-2 px-md-4 py-md-4 p-lg-6 d-flex flex-column align-items-center justify-content-between"
       >

--- a/src/components/forms/lib/handleDemoSubmit.ts
+++ b/src/components/forms/lib/handleDemoSubmit.ts
@@ -55,10 +55,12 @@ const redirect = (values: ParsedFormValues) => {
 export const handleDemoSubmit = async ({
   values,
   event,
+  slug,
   setFormStatus,
 }: {
   values: FormValues;
   event: React.FormEvent<HTMLFormElement>;
+  slug: string;
   setFormStatus: (arg0: string) => void;
 }): Promise<void> => {
   event.preventDefault();
@@ -94,7 +96,7 @@ export const handleDemoSubmit = async ({
   }
 
   const eventName = `getDemo.submit.${requesterType}`;
-  track(eventName, { value });
+  track(eventName, { value, slug });
   track('captureLead');
 
   redirect(parsedFormValues);

--- a/src/layouts/customLandingPage.tsx
+++ b/src/layouts/customLandingPage.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+
+import { dynamicI18n } from '../helpers';
+import { ComponentPicker } from '../components';
+import { Title } from '../layouts/utils';
+
+const CustomLandingPage = ({
+  data,
+  prefix,
+}: Props & {
+  data: {
+    contentfulCustomLandingPageWithBanner: CustomLandingPageProps;
+    allContentfulCustomLandingPageWithBanner: UnknownObject;
+  };
+}) => {
+  const { title, description, entries } = data.contentfulCustomLandingPageWithBanner;
+
+  return (
+    <div>
+      <Title title={dynamicI18n(title)} description={dynamicI18n(description)} indexable />
+      {entries.map((entry) => (
+        <ComponentPicker key={entry.id} entry={entry} prefix={prefix} />
+      ))}
+    </div>
+  );
+};
+
+export default CustomLandingPage;
+
+export const customLandingPageQuery = graphql`
+  query ($id: String!) {
+    contentfulCustomLandingPageWithBanner(id: { eq: $id }) {
+      id
+      slug
+      title
+      description
+      entries {
+        ... on ContentfulTopBanner {
+          id
+          __typename
+          mainHeader
+          description
+          firstButtonText
+          firstButtonUrl
+          secondButtonText
+          secondButtonUrl
+          image {
+            localFile {
+              childImageSharp {
+                fluid(maxWidth: 1200, quality: 100) {
+                  ...GatsbyImageSharpFluid
+                }
+              }
+            }
+          }
+        }
+        ...FeatureGridFragment
+        ...TestimonialFragment
+        ...LogoBannerFragment
+        ...SelectableCardsWithScreenshotsFragment
+        ...CallToAction2021Fragment
+        ...ChecklistWithScreenshotFragment
+      }
+    }
+  }
+`;

--- a/src/layouts/demo.tsx
+++ b/src/layouts/demo.tsx
@@ -19,6 +19,7 @@ type DemoPageProps = {
   header: string;
   description: string;
   formButtonText: string;
+  slug: string;
   requesterType?: RequesterType;
 };
 
@@ -47,15 +48,26 @@ const SourceforgeBadge = () => (
 
 const DemoPage = (props: Props) => {
   const { data, prefix } = props;
-  const { content, title, header, description, formButtonText, requesterType }: DemoPageProps =
-    data.contentfulDemoPage2021;
+  const {
+    content,
+    title,
+    header,
+    description,
+    formButtonText,
+    requesterType,
+    slug,
+  }: DemoPageProps = data.contentfulDemoPage2021;
 
   const buttonOne = <CapterraBadge />;
   const buttonTwo = <G2Badge />;
   const buttonThree = <SourceforgeBadge />;
 
   const form = (
-    <DemoForm buttonText={dynamicI18n(formButtonText)} contentfulRequesterType={requesterType} />
+    <DemoForm
+      buttonText={dynamicI18n(formButtonText)}
+      contentfulRequesterType={requesterType}
+      slug={slug}
+    />
   );
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -81,6 +81,33 @@ export const TestimonialCardsFragment = graphql`
   }
 `;
 
+export const TestimonialFragment = graphql`
+  fragment TestimonialFragment on ContentfulTestimonials {
+    id
+    __typename
+    header
+    testimonial {
+      name
+      description {
+        childMdx {
+          body
+        }
+      }
+      url
+      image {
+        localFile {
+          childImageSharp {
+            fixed(height: 120) {
+              ...GatsbyImageSharpFixed
+            }
+          }
+        }
+      }
+      small
+    }
+  }
+`;
+
 export const ContentWithChecklistFragment = graphql`
   fragment ContentWithChecklistFragment on ContentfulContentWithChecklist {
     id


### PR DESCRIPTION
@almasen I have splitted the PR into 3 commits to make it easier to review:

### Commit 1: Testimonial component
Now testimonial like the ones in the example, can be queried from contentful instead of having to hardcoding them
![image](https://user-images.githubusercontent.com/86734894/148092312-daad08d7-5d3a-4639-97e5-24d94eb15b22.png)

### Commit 2: Google Analytics improvements
Now we pass the `slug` of the page from where user book the demo requests to Analytics

### Commit 3: Generate custom Landing pages
With this PR, we can generate 100% flexible landing pages. The behavior should be similar to the `ledgy.com/src/layouts/featurePage.tsx` file.

We query the structure of the landing pages we want to create on the `gatsby-node.js` file.
We generate the pages with the `createLocalizedPages` function on that same file. We pass the queried data to `customLandingPage.tsx` and generate the pages with that template.

An example of a generated landing page can be found at `/20vc` on the Netifly deploy
![image](https://user-images.githubusercontent.com/86734894/148087637-2835f0db-6be0-4c97-9f30-4655b2400655.png)
