### PR TITLE
Fix language selector index

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -71,7 +71,7 @@ export const Footer = ({ location, ...props }: LayoutProps) => {
             </FooterCol>
             <FooterCol order={1}>
               <div className="footer--logo-section d-flex flex-column justify-content-between mt-5 mt-md-0">
-                <div className="d-flex flex-column align-items-center p-0 px-md-4">
+                <div className="d-flex flex-column align-items-center p-0 px-md-4 z-index-base">
                   <Link to={`${prefix}/#start`} className="mb-2 mb-md-4">
                     <img src={logoInvertedCompact} width={80} alt={name} />
                   </Link>
@@ -102,7 +102,7 @@ export const Footer = ({ location, ...props }: LayoutProps) => {
                     />
                   </div>
                 </div>
-                <div className="d-flex justify-content-center flex-wrap mt-5">
+                <div className="d-flex justify-content-center flex-wrap mt-5 z-index-background">
                   {socialLinks.map(([href, icon, title]) => (
                     <a
                       href={href}


### PR DESCRIPTION
The new Z-index of the language selector is higher than the one from the social networks links. If you look closely you can see the social logos appearing over the word `Deutsh` in the first image.

### BEFORE
![image](https://user-images.githubusercontent.com/86734894/148755774-b79f141d-a213-4877-b053-f51a54fc8614.png)



### NOW
![image](https://user-images.githubusercontent.com/86734894/148755700-3671dd91-dfcd-4dcf-9fa0-55d570ad688b.png)
