### PR TITLE
Added Legal team email to the Contact Page

### DIFF
--- a/src/components/ContactUs/Emails.tsx
+++ b/src/components/ContactUs/Emails.tsx
@@ -32,11 +32,17 @@ export const Emails = () => (
       </h6>
       <a href="mailto:work@ledgy.com">work@ledgy.com</a>
     </div>
-    <div>
+    <div className="mb-4">
       <h6>
         <Trans>General</Trans>
       </h6>
       <a href="mailto:contact@ledgy.com">contact@ledgy.com</a>
+    </div>
+    <div>
+      <h6>
+        <Trans>Legal</Trans>
+      </h6>
+      <a href="mailto:legal@ledgy.com">legal@ledgy.com</a>
     </div>
   </div>
 );


### PR DESCRIPTION
As requested by Nico, I have added the legal team email on the `Contact` page

![image](https://user-images.githubusercontent.com/86734894/149105644-307f12ac-1d8b-4733-b282-654fc99b0caf.png)
