### PR TITLE
Remove defer from optimize tag 

### DIFF
--- a/src/components/HelmetIndexLayout.tsx
+++ b/src/components/HelmetIndexLayout.tsx
@@ -41,7 +41,9 @@ export const HelmetIndexLayout = ({
       <link rel="alternate" href={`${siteUrl}/de${pathname}`} hrefLang="de" />
       <link rel="alternate" href={`${siteUrl}/fr${pathname}`} hrefLang="fr" />
       <link rel="canonical" href={`${siteUrl}${langPrefix(lang)}${pathname}`} />
-      <script defer src="https://www.googleoptimize.com/optimize.js?id=OPT-NXHX8ZG" />
+      {siteUrl.includes('https://ledgy.com') && (
+        <script src="https://www.googleoptimize.com/optimize.js?id=OPT-K7Q54LK" />
+      )}
 
       {/* Disable AOS for Google */}
       <noscript>

--- a/src/components/nav/NavbarButtons.tsx
+++ b/src/components/nav/NavbarButtons.tsx
@@ -17,14 +17,15 @@ const SignupLoginButton = () => {
     setButtonType(hasAccount ? LOGIN : SIGNUP);
   });
 
+  const isLogin = buttonType === LOGIN;
   return (
     <Button
       inverted
       outline
-      href={appUrl}
+      href={isLogin ? appUrl : appUrl + '/signup'}
       className={`px-3 py-1 ${buttonType ? 'visible' : 'invisible'}`}
     >
-      {buttonType === LOGIN ? <Trans>Log In</Trans> : <Trans>Sign Up</Trans>}
+      {isLogin ? <Trans>Log In</Trans> : <Trans>Sign Up</Trans>}
     </Button>
   );
 };


### PR DESCRIPTION
Remove `defer` from `Google optimize tag` and activate only on prod

Quick fix asked by Ben: Redirect users to `app.ledgy.com` if they click on the Sign Up button