### PR TITLE
Remove `legal@ledgy.com` email address from website

### DIFF
--- a/src/components/ContactUs/Emails.tsx
+++ b/src/components/ContactUs/Emails.tsx
@@ -32,17 +32,11 @@ export const Emails = () => (
       </h6>
       <a href="mailto:work@ledgy.com">work@ledgy.com</a>
     </div>
-    <div className="mb-4">
+    <div>
       <h6>
         <Trans>General</Trans>
       </h6>
       <a href="mailto:contact@ledgy.com">contact@ledgy.com</a>
-    </div>
-    <div>
-      <h6>
-        <Trans>Legal</Trans>
-      </h6>
-      <a href="mailto:legal@ledgy.com">legal@ledgy.com</a>
     </div>
   </div>
 );


### PR DESCRIPTION
Check that `legal@ledgy.com` is not showing anymore on [the contact page](https://deploy-preview-592--ledgy.netlify.app/contact/)