### PR TITLE
add utm to parneship pages

### DIFF
--- a/src/redirects.js
+++ b/src/redirects.js
@@ -4,9 +4,9 @@ const pricing = '/company-pricing/';
 const stateOfEquity = 'https://stateofequity.ledgy.com';
 const signup = appUrl + '/signup';
 
-const getPartnershipsRedirect = (url) => {
-  const baseUrl = `/${url}`;
-  return [baseUrl, `${baseUrl}/?utm_source=${url}`];
+const getKeyValueRedirectRoutes = (utmParam) => {
+  const route = `/${utmParam}`;
+  return [route, `${route}/?utm_source=${utmParam}`];
 };
 
 const partnerships = ['20vc', 'sifted', 'startup-cfo', 'antler', 'techstars', 'embedded-capital'];

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -10,7 +10,7 @@ const getPartnershipsRedirect = (url) => {
 };
 
 const partnerships = ['20vc', 'sifted', 'startup-cfo', 'antler', 'techstars', 'embedded-capital'];
-const parnershipsRedirects = partnerships.map(getPartnershipsRedirect);
+const parnershipsRedirects = partnerships.map(getKeyValueRedirectRoutes);
 
 // eslint-disable-next-line no-undef
 exports.redirects = [

--- a/src/redirects.js
+++ b/src/redirects.js
@@ -4,6 +4,14 @@ const pricing = '/company-pricing/';
 const stateOfEquity = 'https://stateofequity.ledgy.com';
 const signup = appUrl + '/signup';
 
+const getPartnershipsRedirect = (url) => {
+  const baseUrl = `/${url}`;
+  return [baseUrl, `${baseUrl}/?utm_source=${url}`];
+};
+
+const partnerships = ['20vc', 'sifted', 'startup-cfo', 'antler', 'techstars', 'embedded-capital'];
+const parnershipsRedirects = partnerships.map(getPartnershipsRedirect);
+
 // eslint-disable-next-line no-undef
 exports.redirects = [
   ['/esop', esopTemplates],
@@ -14,6 +22,7 @@ exports.redirects = [
   ['/pricing', pricing],
   ['/features', '/'],
   ['/g2', '/?utm_source=g2'],
+  ...parnershipsRedirects,
 
   //external links
   ['/signup', signup],


### PR DESCRIPTION
Generate `utm_source` links for custom landing pages to improve source tracking