### PR TITLE
Add an identify segment call when emails are submitted

### DIFF
--- a/src/components/forms/SubscriptionForm.tsx
+++ b/src/components/forms/SubscriptionForm.tsx
@@ -9,6 +9,7 @@ import { Button } from '../utils';
 import { trackOnMixpanel, FORM_STATUSES, submitToHubspotNewsletter } from './lib';
 import { InvalidFieldHints } from './Fields';
 import { NEWSLETTER } from './lib/constants';
+import { identifyOrAlias } from '../../helpers';
 
 const { FETCH_ERROR, IDLE, INVALID_EMAIL, LOADING } = FORM_STATUSES;
 
@@ -34,6 +35,7 @@ export class SubscriptionForm extends Component<
 
     try {
       const signupResponse = await submitToHubspotNewsletter(parsedFormValues);
+      identifyOrAlias(email);
       if (signupResponse.status === 200) {
         trackOnMixpanel(email, trackingEvent);
         this.setState({ email: '', status: IDLE });

--- a/src/components/forms/lib/handleDemoSubmit.ts
+++ b/src/components/forms/lib/handleDemoSubmit.ts
@@ -1,4 +1,10 @@
-import { isFieldMissing, isValidEmail, track, setDomainCookie } from '../../../helpers';
+import {
+  isFieldMissing,
+  isValidEmail,
+  track,
+  setDomainCookie,
+  identifyOrAlias,
+} from '../../../helpers';
 
 import { FormValues, ParsedFormValues } from './formTypes';
 import { submitToHubspot } from './hubspot';
@@ -133,6 +139,7 @@ export const handleDemoSubmit = async ({
   } else {
     track('TagManagerSmallCompany');
   }
+  identifyOrAlias(email);
 
   track(eventName, { value, pathname, size, email });
   track('captureLead');

--- a/src/helpers/utilities.ts
+++ b/src/helpers/utilities.ts
@@ -1,10 +1,23 @@
 export const track = (event: string, properties?: UnknownObject): void => {
   if (window.analytics) window.analytics.track(event, properties);
 };
-export const identify = (event: string, properties?: UnknownObject): void => {
-  if (window.analytics) window.analytics.identify(event, properties);
+export const identify = (id: string, properties?: UnknownObject): void => {
+  if (window.analytics) window.analytics.identify(id, properties);
 };
-
+const alias = (currentId: string, previousID: string): void => {
+  if (window.analytics) window.analytics.alias(currentId, previousID);
+};
+const getCurrentSegmentId = (): string | undefined => {
+  if (window.analytics) return window.analytics.user().id();
+};
+export const identifyOrAlias = (id: string, properties?: UnknownObject) => {
+  const oldSegmentId = getCurrentSegmentId();
+  if (oldSegmentId) {
+    alias(id, oldSegmentId);
+  } else {
+    identify(id, properties);
+  }
+};
 type ClickOptions = { text: string; url: string };
 
 export const trackClick = (value: string, options?: ClickOptions) => {


### PR DESCRIPTION
Add an `identify` segment call when emails are submitted. 
If the user already has an ID, use the `alias` method