### PR TITLE
Add top banners into the Regional Component Picker

### DIFF
--- a/src/components/blog/PostFilters.tsx
+++ b/src/components/blog/PostFilters.tsx
@@ -11,7 +11,7 @@ export const PostFilters = ({
   <div className="blogfilters__wrapper">
     <div className="blogfilters__title">Browse Ledgy’s posts!</div>
     <div className="blogfilters__subtitle">
-      Want to go deeper? Click on a category below to lear more about a specific subject.
+      Want to go deeper? Click on a category below to learn more about a specific subject.
     </div>
     <div className="blogfilters__row">
       <div className="blogfilters__tags">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -149,18 +149,22 @@ export const RegionalComponentPickerFragment = graphql`
       global {
         ...LogoBannerFragment
         ...FeatureGridFragment
+        ...ContentfulTopBannerFragment
       }
       uk {
         ...LogoBannerFragment
         ...FeatureGridFragment
+        ...ContentfulTopBannerFragment
       }
       de {
         ...LogoBannerFragment
         ...FeatureGridFragment
+        ...ContentfulTopBannerFragment
       }
       fr {
         ...LogoBannerFragment
         ...FeatureGridFragment
+        ...ContentfulTopBannerFragment
       }
     }
   }


### PR DESCRIPTION
#### Description
Now also the top banner can change based on location.

#### Test steps
- [ ] Visit the path `/test-landingpage` and check how the top banner text changes based on your IP. Use proton VPN to visit the page from UK and Germany 
`(works only on preview mode)`

To test locally, visit `de/test-landingpage` & `uk/test-landingpage`

#### Screenshots

### Germany
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/86734894/179026997-fb8e2653-065d-4b11-935d-3364138a8584.png">

### UK
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/86734894/179027080-1d289518-5f05-4147-aa1b-4e7bcf07fc03.png">



